### PR TITLE
style: button default 스타일 수정 (#43)

### DIFF
--- a/src/pages/results/ui/results-control.tsx
+++ b/src/pages/results/ui/results-control.tsx
@@ -52,7 +52,6 @@ const ActionButton = ({
 }: ActionButtonProps) => (
   <Button
     variant='ghost'
-    size='icon'
     aria-label={ariaLabel}
     onClick={onClick}
     className='size-fit p-1 focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-4 focus-visible:ring-offset-white'

--- a/src/pages/speller/ui/speller-control.tsx
+++ b/src/pages/speller/ui/speller-control.tsx
@@ -18,7 +18,8 @@ const SpellerControl: FC<SpellerControlProps> = ({ count, isSubmitted }) => {
       <TextCounter count={count} />
       <Button
         type='submit'
-        className='h-[3.375rem] w-[8rem]'
+        variant='action'
+        className='h-[3.375rem] w-[8rem] pc:h-[4.0625rem] pc:w-[9.625rem]'
         disabled={isButtonDisabled}
       >
         {isSubmitted ? '검사중...' : '검사하기'}

--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -5,12 +5,11 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/shared/lib/tailwind-merge'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[0.5rem] text-lg font-semibold ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:bg-muted disabled:text-muted-foreground pc:text-[1.3125rem] [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default:
-          'bg-blue-500 text-white hover:bg-blue-500/90 focus-visible:ring-blue-500',
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
           'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline:
@@ -19,13 +18,14 @@ const buttonVariants = cva(
           'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
+        action:
+          'rounded-lg bg-primary text-lg font-semibold text-primary-foreground disabled:bg-slate-300 disabled:text-muted-foreground pc:text-xl',
       },
       size: {
-        default:
-          'h-[3.375rem] px-[1.94rem] py-[0.62rem] pc:px-[2.31rem] pc:py-[0.75rem]',
-        sm: 'h-9 rounded-md px-3',
-        lg: 'h-11 rounded-md px-8',
-        icon: 'h-10 w-10',
+        default: 'h-9 px-4 py-2',
+        sm: 'h-8 rounded-md px-3 text-xs',
+        lg: 'h-10 rounded-md px-8',
+        icon: 'h-9 w-9',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## 작업 내역
- button 컴포넌트의 default 스타일을 action variant 스타일로 변경
- '검사하기' 버튼 스타일 수정

## 스크린샷
![스크린샷 2025-01-21 오전 12 10 43](https://github.com/user-attachments/assets/0efc0d11-aa61-452e-906c-0d2af23cd7b9)
![스크린샷 2025-01-21 오전 12 10 50](https://github.com/user-attachments/assets/1c18a747-90c4-4cd5-85cd-6d753f02cf3f)
