### PR TITLE
[#82] 전체복사 시 미교정 오류어에 대한 로그 API 호출

### DIFF
--- a/src/entities/speller/api/speller-service.ts
+++ b/src/entities/speller/api/speller-service.ts
@@ -2,7 +2,11 @@ import { AxiosResponse } from 'axios'
 
 import { Client } from '@/shared/api/client'
 import { ENDPOINT } from '@/shared/model/constants'
-import { SpellerService, UserReplacePayload } from '../model/speller-interface'
+import {
+  NotChangePayload,
+  SpellerService,
+  UserReplacePayload,
+} from '../model/speller-interface'
 import {
   CheckPayload,
   CheckResponse,
@@ -28,8 +32,8 @@ class SpellerApiService implements SpellerService {
     return this.#client.post(ENDPOINT.CLICK_REPLACE, payload)
   }
 
-  async notChange() {
-    return this.#client.post(ENDPOINT.NOT_CHANGE) // FIXME: payload 추가
+  async notChange(payload: NotChangePayload) {
+    return this.#client.post(ENDPOINT.NOT_CHANGE, payload)
   }
 }
 

--- a/src/entities/speller/index.ts
+++ b/src/entities/speller/index.ts
@@ -1,6 +1,9 @@
 export { SpellerApi } from './api/speller-service'
 export { parseCandidateWords } from './lib/parse-candidate-words'
-export type { UserReplacePayload } from './model/speller-interface'
+export type {
+  UserReplacePayload,
+  NotChangePayload,
+} from './model/speller-interface'
 export {
   CorrectMethodEnum,
   checkPayloadSchema,

--- a/src/entities/speller/model/speller-interface.ts
+++ b/src/entities/speller/model/speller-interface.ts
@@ -11,9 +11,15 @@ export interface UserReplacePayload {
   sentence: string // 오류 문자열을 포함한 주변 문맥 문자열 (오류 문자열 좌/우)
 }
 
+export type NotChangePayload = {
+  errorWord: string // 오류 문자열
+  replaceWord: string // 1순위 대치어
+  sentence: string // 오류 문자열을 포함한 주변 문맥 문자열 (오류 문자열 좌/우)
+}[]
+
 export interface SpellerService {
   check: (payload: CheckPayload) => Promise<AxiosResponse<CheckResponse>>
   logUserReplace: (payload: UserReplacePayload) => void
   logClickReplace: (payload: ClickReplacePayload) => void
-  notChange: () => void
+  notChange: (payload: NotChangePayload) => void
 }

--- a/src/pages/results/api/log-copy-action.ts
+++ b/src/pages/results/api/log-copy-action.ts
@@ -1,0 +1,16 @@
+'use server'
+
+import { NotChangePayload, SpellerApi } from '@/entities/speller'
+import axios from 'axios'
+
+export const logCopyAction = async (payload: NotChangePayload) => {
+  try {
+    await SpellerApi.notChange(payload)
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      throw new Error(error.message)
+    } else {
+      throw new Error(String(error))
+    }
+  }
+}

--- a/src/pages/results/ui/results-control.tsx
+++ b/src/pages/results/ui/results-control.tsx
@@ -9,10 +9,13 @@ import { TextCounter } from '@/shared/ui/text-counter'
 import { useSpeller } from '@/entities/speller'
 import { useRouter } from 'next/navigation'
 import { toast } from '@/shared/lib/use-toast'
+import { logCopyAction } from '../api/log-copy-action'
+import { getWordsAroundIndex } from '@/shared/lib/util'
 
 const ResultsControl = () => {
   const {
     response: { str },
+    correctInfo,
   } = useSpeller()
   const router = useRouter()
   const { copyText } = useClipboard()
@@ -22,6 +25,15 @@ const ResultsControl = () => {
     toast({
       description: '복사 완료!\n원하는 곳에 붙여넣어 보세요.',
     })
+
+    const unfixedErrors = Object.values(correctInfo)
+      .filter(item => !item?.crtStr)
+      .map(item => ({
+        errorWord: item.orgStr,
+        replaceWord: item.candWord.split('|')[0],
+        sentence: getWordsAroundIndex(str, item.start),
+      }))
+    logCopyAction(unfixedErrors)
   }
 
   return (

--- a/src/shared/ui/toaster.tsx
+++ b/src/shared/ui/toaster.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/shared/ui/toast'
 import WarningIcon from '@/shared/ui/icon/toast-warning.svg'
 import CheckIcon from '@/shared/ui/icon/toast-check.svg'
+import React from 'react'
 
 export function Toaster() {
   const { toasts } = useToast()
@@ -24,18 +25,18 @@ export function Toaster() {
               {title && <ToastTitle>{title}</ToastTitle>}
               {description && (
                 <ToastDescription>
-                  <div key={id} className='flex items-center gap-[1.03rem]'>
+                  <div className='flex items-center gap-[1.03rem]'>
                     {props.variant === 'destructive' ? (
                       <WarningIcon />
                     ) : (
                       <CheckIcon />
                     )}
                     {typeof description === 'string'
-                      ? description.split('\n').map(text => (
-                          <>
+                      ? description.split('\n').map((text, index) => (
+                          <React.Fragment key={index}>
                             {text}
                             <br />
-                          </>
+                          </React.Fragment>
                         ))
                       : description}
                   </div>


### PR DESCRIPTION
## 작업내역
- 전체복사 시 미교정 오류어에 대한 로그 API 호출
  - `correctInfo` 에서 `crtStr` 값이 없는 경우 미교정 오류어로 판단
- 복사 시 출력되는 토스트에서 발생하는 key 관련 에러 수정

close #82 