### PR TITLE
#87: 교정 취소기능 추가

### DIFF
--- a/src/pages/results/ui/error-info-section.tsx
+++ b/src/pages/results/ui/error-info-section.tsx
@@ -42,18 +42,26 @@ const ErrorInfoSection = <T extends HTMLDivElement>({
     })
   }
 
+  const handleRevert = () => {
+    handleUpdateCorrectInfo({ ...errorInfo, crtStr: orgStr })
+  }
+
   return (
     <div className={cn('my-[1.125rem]', errorIdx === 0 && 'mt-0')} {...props}>
       <dl className='grid grid-cols-[3.5rem_1fr] gap-3 tab:grid-cols-[4.75rem_1fr] pc:grid-cols-[4.5rem_1fr] pc:gap-1'>
         <dt className='py-0.5 text-sm font-semibold tab:text-lg'>입력 내용</dt>
         <dd className='flex items-center justify-between'>
-          <p className='flex items-center gap-2 text-base font-semibold tab:gap-3.5 tab:text-xl'>
+          <Button
+            variant='ghost'
+            className='flex h-auto items-center gap-2 p-0 text-base font-semibold hover:bg-transparent tab:gap-3.5 tab:text-xl'
+            onClick={handleRevert}
+          >
             <BulletBadge
               method={correctMethod}
               className='mx-1.5 size-3 tab:mx-2.5'
             />
             {orgStr}
-          </p>
+          </Button>
           <ReportForm>
             <Button
               variant='ghost'

--- a/src/pages/results/ui/error-info-section.tsx
+++ b/src/pages/results/ui/error-info-section.tsx
@@ -16,6 +16,7 @@ import { HelpSection } from './help-section'
 import { CustomTextEditor } from './custom-text-editor'
 import { logClickReplaceAction } from '../api/log-click-replace-action'
 import { extractContext } from '../lib/extractContext'
+import { XIcon } from 'lucide-react'
 
 interface ErrorInfoSectionProps<T>
   extends React.RefAttributes<T>,
@@ -91,21 +92,32 @@ const ErrorInfoSection = <T extends HTMLDivElement>({
           </CustomTextEditor>
           <div className='mt-2 flex max-h-[5.625rem] flex-col overflow-y-auto rounded-lg border border-slate-200 bg-slate-100 p-2 tab:mt-3 tab:max-h-[6rem] pc:max-h-[6.5rem]'>
             {candidateWords.map(({ id, word }) => (
-              <Button
-                key={id}
-                variant={null}
-                className={cn(
-                  'h-auto justify-start p-0 text-base font-medium hover:underline tab:text-base pc:text-lg',
-                  correctInfo[errorIdx]?.crtStr === word &&
-                    'font-bold text-blue-500',
+              <div key={id} className='flex items-center gap-[0.43rem]'>
+                <Button
+                  variant={null}
+                  className={cn(
+                    'h-auto justify-start p-0 text-base font-medium hover:underline tab:text-base pc:text-lg',
+                    correctInfo[errorIdx]?.crtStr === word &&
+                      'font-bold text-blue-500',
+                  )}
+                  onClick={() => {
+                    handleUpdateCorrectInfo({ ...errorInfo, crtStr: word })
+                    if (id > 0) handleClickReplace(word)
+                  }}
+                >
+                  {word}
+                </Button>
+                {correctInfo[errorIdx]?.crtStr === word && (
+                  <Button
+                    size='icon'
+                    variant='outline'
+                    className='size-[1.125rem] rounded-full border-0 bg-white text-slate-400 shadow-sm hover:bg-white pc:size-5'
+                    onClick={() => handleRevert()}
+                  >
+                    <XIcon className='!w-3 pc:!w-3.5' />
+                  </Button>
                 )}
-                onClick={() => {
-                  handleUpdateCorrectInfo({ ...errorInfo, crtStr: word })
-                  if (id > 0) handleClickReplace(word)
-                }}
-              >
-                {word}
-              </Button>
+              </div>
             ))}
           </div>
         </dd>


### PR DESCRIPTION
## 작업내역
- 입력 내용 클릭 시 기존 단어 표시
- 대치어 목록의 취소 버튼 클릭 시 기존 단어 표시

<img width="594" alt="image" src="https://github.com/user-attachments/assets/55e30697-3959-4ecd-abc4-de8fb70e9744" />

close #87 