### PR TITLE
chore: client config 수정(timeout, headers 옵션 제거) (#112)

### DIFF
--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,13 +1,7 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 
-const DEFAULT_TIMEOUT = 30000
-
 const defaultConfig: AxiosRequestConfig = {
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
-  timeout: DEFAULT_TIMEOUT,
-  headers: {
-    'x-api-key': process.env.NEXT_PUBLIC_API_KEY,
-  },
 }
 
 const defaultAxiosInstance = axios.create(defaultConfig)


### PR DESCRIPTION
## 작업 내역
- client `defaultConfig`에서 `timeout`, `headers` 옵션 제거

close #112 