### PR TITLE
fix: 교정단어 클릭 시 기존 문장이 복사되는 문제 (#104)

### DIFF
--- a/src/entities/speller/lib/apply-corrections.ts
+++ b/src/entities/speller/lib/apply-corrections.ts
@@ -1,0 +1,27 @@
+import { CorrectInfo } from '../model/speller-schema'
+
+export const applyCorrections = (
+  originalText: string,
+  correctInfo: Record<number, CorrectInfo>,
+) => {
+  let displayText = originalText
+  let offset = 0
+
+  Object.values(correctInfo).forEach(({ start, end, crtStr }) => {
+    // 앞의 변경이 적용되었으므로 새로운 인덱스를 계산
+    const adjustedStart = start + offset
+    const adjustedEnd = end + offset
+
+    if (!crtStr) return
+
+    displayText =
+      displayText.slice(0, adjustedStart) +
+      crtStr +
+      displayText.slice(adjustedEnd)
+
+    // 문자열 길이 차이를 반영하여 offset 조정
+    offset += crtStr.length - (end - start)
+  })
+
+  return displayText
+}

--- a/src/entities/speller/model/speller-slice.ts
+++ b/src/entities/speller/model/speller-slice.ts
@@ -3,11 +3,13 @@
 import { createSlice } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { CheckResponse, CorrectInfo } from './speller-schema'
+import { applyCorrections } from '../lib/apply-corrections'
 
 type Response = CheckResponse & { requestedWithStrictMode: boolean }
 
 interface SpellerState {
-  text: string
+  text: string // 입력된 텍스트 원본
+  displayText: string // 교정문서에 표시되는 텍스트
   response: Response
   responseMap: Record<number, Response>
   correctInfo: Record<number, CorrectInfo>
@@ -16,6 +18,7 @@ interface SpellerState {
 
 const initialState: SpellerState = {
   text: '',
+  displayText: '',
   response: {
     str: '',
     errInfo: [],
@@ -37,6 +40,7 @@ const spellerSlice = createSlice({
     },
 
     updateResponse: (state, action: PayloadAction<Response>) => {
+      state.displayText = action.payload.str
       state.response = action.payload
       state.correctInfo = action.payload.errInfo.reduce(
         (acc, info) => ({ ...acc, [info.errorIdx]: info }),
@@ -46,6 +50,11 @@ const spellerSlice = createSlice({
 
     updateCorrectInfo: (state, action: PayloadAction<CorrectInfo>) => {
       state.correctInfo[action.payload.errorIdx] = action.payload
+
+      state.displayText = applyCorrections(
+        state.response.str,
+        state.correctInfo,
+      )
     },
 
     setSelectedErrIdx: (state, action: PayloadAction<number>) => {

--- a/src/pages/results/ui/results-control.tsx
+++ b/src/pages/results/ui/results-control.tsx
@@ -14,6 +14,7 @@ import { getWordsAroundIndex } from '@/shared/lib/util'
 
 const ResultsControl = () => {
   const {
+    displayText,
     response: { str },
     correctInfo,
   } = useSpeller()
@@ -21,7 +22,7 @@ const ResultsControl = () => {
   const { copyText } = useClipboard()
 
   const handleCopy = () => {
-    copyText(str)
+    copyText(displayText)
     toast({
       description: '복사 완료!\n원하는 곳에 붙여넣어 보세요.',
     })


### PR DESCRIPTION
## 작업 내역
- 원복 텍스트(`str`)가 아닌 교정된 텍스트(`displayText`)가 복사되도록 수정하였습니다.
- slice에 교정 텍스트를 관리할 displayText 상태를 새로 추가했습니다. 단어가 교정될 때 displayText도 업데이트됩니다.

close #104 