### PR TITLE
feat: "자세히 보기" 버튼 노출 조건 수정 (#119)

### DIFF
--- a/src/pages/results/ui/help-section.tsx
+++ b/src/pages/results/ui/help-section.tsx
@@ -20,9 +20,11 @@ const HelpSection = ({ help }: HelpSectionProps) => {
   const checkContentHeight = useDebounce(() => {
     if (!contentRef.current) return
 
-    let threshold = 4.5 * 16 // mobile
-    if (width! >= 726) threshold = 3.5 * 16 // tab
-    if (width! >= 1377) threshold = 3 * 16 // pc
+    const rem = 16
+    // threshold: 각 디바이스 화면에서 도움말이 2줄까지 보이는 높이
+    let threshold = 4.5 * rem // mobile
+    if (width! >= 726) threshold = 3.5 * rem // tab
+    if (width! >= 1377) threshold = 3 * rem // pc
 
     setShowButton(contentRef.current.scrollHeight > threshold)
   }, 300)

--- a/src/pages/results/ui/help-section.tsx
+++ b/src/pages/results/ui/help-section.tsx
@@ -1,4 +1,8 @@
-import React, { useState } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
+import {
+  useDebounce,
+  useWindowSize,
+} from '@frontend-opensource/use-react-hooks'
 import { Button } from '@/shared/ui/button'
 import { cn } from '@/shared/lib/tailwind-merge'
 import ArrowBottomIcon from '@/shared/ui/icon/icon-arrow-bottom.svg'
@@ -9,6 +13,27 @@ interface HelpSectionProps {
 
 const HelpSection = ({ help }: HelpSectionProps) => {
   const [isExpanded, setIsExpanded] = useState<boolean>(false)
+  const [showButton, setShowButton] = useState<boolean>(false)
+  const contentRef = useRef<HTMLParagraphElement>(null)
+  const { width } = useWindowSize()
+
+  const checkContentHeight = useDebounce(() => {
+    if (!contentRef.current) return
+
+    let threshold = 4.5 * 16 // mobile
+    if (width! >= 726) threshold = 3.5 * 16 // tab
+    if (width! >= 1377) threshold = 3 * 16 // pc
+
+    setShowButton(contentRef.current.scrollHeight > threshold)
+  }, 300)
+
+  useEffect(() => {
+    checkContentHeight()
+    window.addEventListener('resize', checkContentHeight)
+    return () => {
+      window.removeEventListener('resize', checkContentHeight)
+    }
+  }, [])
 
   return (
     <div
@@ -16,6 +41,7 @@ const HelpSection = ({ help }: HelpSectionProps) => {
         'relative max-h-[4.5rem] overflow-hidden transition-[max-height,padding-bottom] duration-300 tab:max-h-[3.5rem] pc:mt-2 pc:max-h-12',
         isExpanded && '!max-h-full pb-6 tab:pb-7 pc:pb-6',
       )}
+      ref={contentRef}
     >
       <p
         className='text-base tab:text-lg pc:text-base'
@@ -24,8 +50,9 @@ const HelpSection = ({ help }: HelpSectionProps) => {
       <Button
         variant={null}
         className={cn(
-          'absolute bottom-0 right-0 h-6 gap-1 rounded-none bg-white p-0 text-sm font-normal text-slate-600 underline before:absolute before:bottom-0 before:right-full before:h-full before:w-full before:bg-gradient-to-r before:from-transparent before:to-white before:content-[""] tab:h-7 tab:text-base pc:h-auto',
+          'invisible absolute bottom-0 right-0 h-6 gap-1 rounded-none bg-white p-0 text-sm font-normal text-slate-600 underline before:absolute before:bottom-0 before:right-full before:h-full before:w-full before:bg-gradient-to-r before:from-transparent before:to-white before:content-[""] tab:h-7 tab:text-base pc:h-auto',
           isExpanded && 'text-slate-400',
+          showButton && 'visible',
         )}
         onClick={() => setIsExpanded(!isExpanded)}
       >


### PR DESCRIPTION
## 작업 내역
- 디바이스별 도움말 자세히 보기 버튼의 노출 조건을 정의하였습니다.

## 스크린샷

### pc
![스크린샷 2025-03-06 00 52 16](https://github.com/user-attachments/assets/e3c70ef4-b64b-4271-a64e-d9c4cae6efb4)

### tab
![스크린샷 2025-03-06 00 52 38](https://github.com/user-attachments/assets/f1986f78-dc1e-4159-a071-aeb51a6f678e)

### mo
![스크린샷 2025-03-06 00 52 54](https://github.com/user-attachments/assets/2d17db1f-674f-474f-afc4-354a927865db)

close #119 