### PR TITLE
design: 강한 검사 여부 문구 스타일 수정 (#122)

### DIFF
--- a/src/pages/results/ui/strong-check-message.tsx
+++ b/src/pages/results/ui/strong-check-message.tsx
@@ -8,7 +8,7 @@ const StrongCheckMessage = () => {
   } = useSpeller()
 
   return (
-    <div className='flex items-center justify-end gap-2 text-right text-base font-medium leading-[150%] tracking-[-0.02rem] text-slate-300 pc:text-xl pc:tracking-[-0.025rem]'>
+    <div className='flex w-full items-center justify-end text-base font-medium leading-[150%] tracking-[-0.02rem] text-slate-300 pc:text-xl pc:tracking-[-0.025rem]'>
       {requestedWithStrictMode
         ? '강한 검사가 적용되었습니다.'
         : '강한 검사가 적용되지 않았습니다.'}


### PR DESCRIPTION
## 작업 내역
- 강한 검사 여부 문구가 항상 섹션의 우측에 배치되도록 스타일을 수정하였습니다.

## 스크린샷

### mo
![스크린샷 2025-03-06 01 00 50](https://github.com/user-attachments/assets/ccd94ab8-93ff-4ebd-9477-ee78db84178b)

### tab
![스크린샷 2025-03-06 01 01 00](https://github.com/user-attachments/assets/c707f4df-c643-4cb8-bf49-985583ee218a)

### pc
![스크린샷 2025-03-06 01 01 09](https://github.com/user-attachments/assets/1fe4aa69-94c7-4db2-83c7-4eb9d44f33fa)
