### PR TITLE
fix: 모바일 메뉴에 사용법 페이지 링크 추가 (#134)

### DIFF
--- a/src/shared/ui/header.tsx
+++ b/src/shared/ui/header.tsx
@@ -48,7 +48,7 @@ const Header = () => {
             <ul>
               <li className='group'>
                 <Link
-                  href='/'
+                  href='/guide'
                   className='flex items-center gap-2 border-b border-slate-200 px-2 py-2.5 pr-3 text-sm leading-none group-hover:text-primary tab:text-base'
                 >
                   <i


### PR DESCRIPTION
모바일 메뉴에 사용법 페이지 링크 연결이 되어있지 않아 추가하였습니다.