### PR TITLE
design: 페이지버튼 가운데 정렬 (#132)

### DIFF
--- a/src/pages/results/ui/results-page.tsx
+++ b/src/pages/results/ui/results-page.tsx
@@ -8,7 +8,7 @@ import { ErrorTrackingSection } from './error-tracking-section'
 const ResultsPage = () => {
   return (
     <ContentLayout className='pb-8 tab:pb-[2.625rem] pc:pb-12'>
-      <div className='mb-2 mt-[0.94rem] flex min-h-[1.625rem] items-center justify-between tab:mt-[1.75rem] pc:mb-[0.78rem] pc:mt-[1.97rem] pc:min-h-8'>
+      <div className='relative mb-2 mt-[0.94rem] flex min-h-[1.625rem] items-center justify-between tab:mt-[1.75rem] tab:justify-center pc:mb-[0.78rem] pc:mt-[1.97rem] pc:min-h-8'>
         <Navigator />
         <StrongCheckMessage />
       </div>

--- a/src/pages/results/ui/strong-check-message.tsx
+++ b/src/pages/results/ui/strong-check-message.tsx
@@ -8,7 +8,7 @@ const StrongCheckMessage = () => {
   } = useSpeller()
 
   return (
-    <div className='flex w-full items-center justify-end text-base font-medium leading-[150%] tracking-[-0.02rem] text-slate-300 pc:text-xl pc:tracking-[-0.025rem]'>
+    <div className='flex w-full items-center justify-end text-base font-medium leading-[150%] tracking-[-0.02rem] text-slate-300 tab:absolute tab:right-0 tab:w-auto pc:text-xl pc:tracking-[-0.025rem]'>
       {requestedWithStrictMode
         ? '강한 검사가 적용되었습니다.'
         : '강한 검사가 적용되지 않았습니다.'}


### PR DESCRIPTION
## 작업내역
- 탭, pc에서 페이지 버튼이 가운데에 오도록 수정하였습니다.
### MO
<img width="435" alt="image" src="https://github.com/user-attachments/assets/9fbc2a61-9344-4908-947a-d01baec7f19b" />

### Tab
<img width="705" alt="image" src="https://github.com/user-attachments/assets/3f659c45-534c-41dc-aea6-942d6ac05072" />

### PC
<img width="1321" alt="image" src="https://github.com/user-attachments/assets/682c930f-9eda-4a52-9667-8f7b3ad1b251" />
