### PR TITLE
feat: 검사 결과가 여러 페이지일 경우 토스트 알림 표시 (#139)

### DIFF
--- a/src/pages/results/ui/navigator.tsx
+++ b/src/pages/results/ui/navigator.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useSpeller } from '@/entities/speller'
 import { clientSpellCheck } from '../api/client-spell-check'
+import { toast } from '@/shared/lib/use-toast'
 
 const Navigator = () => {
   const { push } = useRouter()
@@ -51,6 +52,14 @@ const Navigator = () => {
       })
     })()
   }, [currentPage, response, responseMap, updateResponseMap])
+
+  useEffect(() => {
+    toast({
+      variant: 'noIcon',
+      description: `총 ${response.totalPageCnt} 페이지입니다.\n화살표를 눌러 페이지를 이동해 주세요.`,
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     response.totalPageCnt > 1 && (

--- a/src/shared/ui/toast.tsx
+++ b/src/shared/ui/toast.tsx
@@ -31,6 +31,7 @@ const toastVariants = cva(
       variant: {
         default: 'bg-slate-400 text-slate-100',
         destructive: 'destructive group bg-slate-600 text-slate-100',
+        noIcon: 'bg-slate-400 text-slate-100',
       },
     },
     defaultVariants: {

--- a/src/shared/ui/toaster.tsx
+++ b/src/shared/ui/toaster.tsx
@@ -26,11 +26,8 @@ export function Toaster() {
               {description && (
                 <ToastDescription>
                   <div className='flex items-center gap-[1.03rem]'>
-                    {props.variant === 'destructive' ? (
-                      <WarningIcon />
-                    ) : (
-                      <CheckIcon />
-                    )}
+                    {props.variant === 'default' && <CheckIcon />}
+                    {props.variant === 'destructive' && <WarningIcon />}
                     {typeof description === 'string'
                       ? description.split('\n').map((text, index) => (
                           <React.Fragment key={index}>


### PR DESCRIPTION
## 작업 내역
2 페이지 이상일 시 토스트 알림 추가하였습니다.

![image](https://github.com/user-attachments/assets/c7fb9d6b-c590-45ea-b7ae-fe720d85d244)


## 참고사항
`response.totalPageCnt`가 변하지 않을 거라고 생각했는데, 이전 페이지 버튼을 누를 때 값이 바뀌는 것 같아 우선 useEffect의 의존성 배열에 포함하지 않았습니다.
```
  useEffect(() => {
    toast({
      variant: 'noIcon',
      description: `총 ${response.totalPageCnt} 페이지입니다.\n화살표를 눌러 페이지를 이동해 주세요.`,
    })
    // eslint-disable-next-line react-hooks/exhaustive-deps
  }, [])
```
@bicochan 제가 아직 페이징쪽을 제대로 분석하지 못했는데, `totalPageCnt`가 변경되도록 의도하신 게 맞는지 확인 부탁드립니다!

close #139 