### PR TITLE
fix: 페이지 변경 시 대치어 적용이 초기화되는 이슈 수정 (#145)

### DIFF
--- a/src/entities/speller/model/use-speller.ts
+++ b/src/entities/speller/model/use-speller.ts
@@ -11,6 +11,7 @@ import {
   setResponseMap,
   resetResponseMap,
   type SpellerState,
+  setCurrentPage,
 } from './speller-slice'
 import { CorrectInfo } from './speller-schema'
 
@@ -57,6 +58,13 @@ const useSpeller = () => {
     dispatch(resetResponseMap())
   }, [dispatch])
 
+  const updateCurrentPage = useCallback(
+    (page: number) => {
+      dispatch(setCurrentPage(page))
+    },
+    [dispatch],
+  )
+
   return {
     ...state,
     handleTextChange,
@@ -65,6 +73,7 @@ const useSpeller = () => {
     updateErrInfoIndex,
     updateResponseMap,
     initResponseMap,
+    updateCurrentPage,
   }
 }
 

--- a/src/pages/results/ui/navigator.tsx
+++ b/src/pages/results/ui/navigator.tsx
@@ -11,8 +11,13 @@ const Navigator = () => {
   const { push } = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
-  const { response, responseMap, handleReceiveResponse, updateResponseMap } =
-    useSpeller()
+  const {
+    response,
+    responseMap,
+    handleReceiveResponse,
+    updateResponseMap,
+    updateCurrentPage,
+  } = useSpeller()
   const [isUpdatedResponseMap, setIsUpdatedResponseMap] = useState(false)
   const currentPage = Number(searchParams?.get('page')) || 1
   const currentPageRef = useRef<number | null>(null)
@@ -27,6 +32,7 @@ const Navigator = () => {
 
   const handlePagination = (page: number) => {
     try {
+      updateCurrentPage(page)
       handleReceiveResponse({ ...responseMap[page] })
     } catch (error) {
       throw new Error(error as string)

--- a/src/pages/results/ui/results-control.tsx
+++ b/src/pages/results/ui/results-control.tsx
@@ -17,6 +17,7 @@ const ResultsControl = () => {
     displayText,
     response: { str },
     correctInfo,
+    currentPage,
   } = useSpeller()
   const router = useRouter()
   const { copyText } = useClipboard()
@@ -27,7 +28,7 @@ const ResultsControl = () => {
       description: '복사 완료!\n원하는 곳에 붙여넣어 보세요.',
     })
 
-    const unfixedErrors = Object.values(correctInfo)
+    const unfixedErrors = Object.values(correctInfo[currentPage])
       .filter(item => !item?.crtStr)
       .map(item => ({
         errorWord: item.orgStr,

--- a/src/pages/results/ui/spelling-correction-text.tsx
+++ b/src/pages/results/ui/spelling-correction-text.tsx
@@ -8,7 +8,8 @@ import { cn } from '@/shared/lib/tailwind-merge'
 
 const SpellingCorrectionText = () => {
   const { correctRefs, scrollSection } = useSpellerRefs()
-  const { response, correctInfo, handleUpdateCorrectInfo } = useSpeller()
+  const { response, correctInfo, handleUpdateCorrectInfo, currentPage } =
+    useSpeller()
   const { str: text } = response
 
   let lastIndex = 0 // useRef 대신 일반 변수 사용 - 매 렌더링마다 초기화 필요
@@ -24,7 +25,7 @@ const SpellingCorrectionText = () => {
     ))
   }
 
-  Object.values(correctInfo).forEach((pos, idx) => {
+  Object.values(correctInfo[currentPage]).forEach((pos, idx) => {
     const isResolved = !!pos.crtStr
     const recommendedWord = pos.candWord.split('|')[0]
 


### PR DESCRIPTION
## 작업 내역
- correctInfo를 페이지마다 관리하도록 변경하였습니다.
- 이전 페이지 버튼을 누른 경우 교정된 내용이 초기화되는 걸 막기 위해, 해당 페이지의 correctInfo가 없을 때만 갱신되도록 처리했습니다. 
```ts
updateResponse: (state, action: PayloadAction<Response>) => {
      state.displayText = action.payload.str
      state.response = action.payload
      // 이미 해당 페이지의 correctInfo가 있을 경우 수정한 내용이 초기화되지 않도록 처리
      if (!state.correctInfo[state.currentPage]) {
        state.correctInfo[state.currentPage] = action.payload.errInfo.reduce(
          (acc, info) => ({ ...acc, [info.errorIdx]: info }),
          {},
        )
      }
    },
```

## 미해결 이슈
result 페이지에서 새로고침 할 경우 correctInfo state가 새로고침 전과 달라지는 문제가 있습니다.
### 새로고침 전
<img width="329" alt="image" src="https://github.com/user-attachments/assets/993419f7-89e4-4eda-9daa-a888d83026d4" />

### 새로고침 후
<img width="645" alt="image" src="https://github.com/user-attachments/assets/75f9daf7-fe90-40ca-b26c-6acc6c44a753" />

이미지처럼 기존에는 correctInfo에 1 ~ 3까지만 key가 존재했는데, 새로고침하면 여러개가 생기는 이슈입니다.
제가 redux-persist 라이브러리가 아직 익숙하지 않아 파악하는데 시간이 걸릴 것 같은데, 혹시 원인 아시는 분 알려주시면 감사하겠습니다🙏