### PR TITLE
feat: 맞춤법/문법 오류 섹션 대치어에 마우스 오버 시 교정 문서 섹션 스크롤 (#167)

### DIFF
--- a/src/entities/speller/model/speller-refs-context.tsx
+++ b/src/entities/speller/model/speller-refs-context.tsx
@@ -7,7 +7,7 @@ import { useSpeller } from './use-speller'
 interface SpellerRefsContextType {
   correctRefs: React.RefObject<HTMLDivElement>[] | null
   errorRefs: React.RefObject<HTMLDivElement>[] | null
-  scrollSection: (target: 'correct' | 'error') => (index: number) => void
+  scrollSection: (target: 'correct' | 'error', index: number) => void
 }
 
 const SpellerRefsContext = createContext<SpellerRefsContextType | null>(null)
@@ -34,7 +34,7 @@ export const SpellerRefsProvider = ({
     : null
 
   const scrollSection = useCallback(
-    (target: 'correct' | 'error') => (index: number) => {
+    (target: 'correct' | 'error', index: number) => {
       const refs = target === 'correct' ? correctRefs : errorRefs
       refs?.[index].current?.scrollIntoView({ behavior: 'smooth' })
     },

--- a/src/pages/results/ui/error-tracking-section.tsx
+++ b/src/pages/results/ui/error-tracking-section.tsx
@@ -13,7 +13,7 @@ import { ErrorInfoSection } from './error-info-section'
 import { BulletBadge } from '../ui/bullet-badge'
 
 const ErrorTrackingSection = () => {
-  const { errorRefs } = useSpellerRefs()
+  const { errorRefs, scrollSection } = useSpellerRefs()
   const { response } = useSpeller()
   const { errInfo } = response ?? {}
 
@@ -37,7 +37,11 @@ const ErrorTrackingSection = () => {
           {errInfo.map((info, idx) => (
             <Fragment key={info.errorIdx}>
               <hr className={cn('border-slate-200', idx === 0 && 'hidden')} />
-              <ErrorInfoSection errorInfo={info} ref={errorRefs?.[idx]} />
+              <ErrorInfoSection
+                errorInfo={info}
+                ref={errorRefs?.[idx]}
+                onMouseOver={() => scrollSection('correct', idx)}
+              />
             </Fragment>
           ))}
         </div>

--- a/src/pages/results/ui/spelling-correction-text.tsx
+++ b/src/pages/results/ui/spelling-correction-text.tsx
@@ -47,7 +47,7 @@ const SpellingCorrectionText = () => {
           isResolved && 'pt-0',
         )}
         ref={correctRefs?.[idx]}
-        onMouseOver={() => scrollSection('error')(idx)}
+        onMouseOver={() => scrollSection('error', idx)}
       >
         <button
           className={cn(


### PR DESCRIPTION
## 작업 내역
- 맞춤법/문법 오류 섹션에서 대치어에 마우스 오버 시 교정 문서 섹션에서 일치하는 대치어가 최상단으로 스크롤되는 기능을 추가했습니다.