### PR TITLE
[#175] (#175 > #161) scroll-container 로직 리팩토링

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -19,17 +19,19 @@ const App = ({
 }>) => {
   return (
     <html lang='ko' className={`${pretendard.variable}`}>
+      <head>
+        {/* Google AdSense */}
+        <Script
+          async
+          src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${process.env.NEXT_PUBLIC_AD_CLIENT}`}
+          crossOrigin='anonymous'
+          strategy='afterInteractive'
+        />
+      </head>
       <body className={`${pretendard.className} antialiased`}>
         {children}
         <Toaster />
       </body>
-      {/* Google AdSense */}
-      <Script
-        defer
-        src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${process.env.NEXT_PUBLIC_AD_CLIENT}`}
-        crossOrigin='anonymous'
-        strategy='afterInteractive'
-      />
     </html>
   )
 }

--- a/src/entities/speller/model/speller-refs-context.tsx
+++ b/src/entities/speller/model/speller-refs-context.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { createContext, useContext, createRef, useRef } from 'react'
-import { useWindowSize } from '@frontend-opensource/use-react-hooks'
 import { useSpeller } from './use-speller'
 import { ScrollContainerHandle } from '@/shared/ui/scroll-container'
+import { useDesktop } from '@/shared/lib/use-desktop'
 
 interface SpellerRefsContextType {
   correctRefs: React.RefObject<HTMLDivElement>[] | null
@@ -23,8 +23,7 @@ export const SpellerRefsProvider = ({
   const correctScrollContainerRef = useRef<ScrollContainerHandle>(null)
   const errorScrollContainerRef = useRef<ScrollContainerHandle>(null)
   const { response, correctInfo } = useSpeller()
-  const { width } = useWindowSize()
-  const isDesktop = width && width >= 1377
+  const isDesktop = useDesktop()
 
   const correctRefs = isDesktop
     ? Array.from({ length: Object.keys(correctInfo).length }, () =>

--- a/src/entities/speller/model/speller-refs-context.tsx
+++ b/src/entities/speller/model/speller-refs-context.tsx
@@ -2,14 +2,14 @@
 
 import { createContext, useContext, createRef, useRef } from 'react'
 import { useWindowSize } from '@frontend-opensource/use-react-hooks'
-import { OverlayScrollbarsComponentRef } from 'overlayscrollbars-react'
 import { useSpeller } from './use-speller'
+import { ScrollContainerHandle } from '@/shared/ui/scroll-container'
 
 interface SpellerRefsContextType {
   correctRefs: React.RefObject<HTMLDivElement>[] | null
   errorRefs: React.RefObject<HTMLDivElement>[] | null
-  correctScrollContainerRef: React.RefObject<OverlayScrollbarsComponentRef> | null
-  errorScrollContainerRef: React.RefObject<OverlayScrollbarsComponentRef> | null
+  correctScrollContainerRef: React.RefObject<ScrollContainerHandle> | null
+  errorScrollContainerRef: React.RefObject<ScrollContainerHandle> | null
   scrollSection: (target: 'correct' | 'error', index: number) => void
 }
 
@@ -20,8 +20,8 @@ export const SpellerRefsProvider = ({
 }: {
   children: React.ReactNode
 }) => {
-  const correctScrollContainerRef = useRef<OverlayScrollbarsComponentRef>(null)
-  const errorScrollContainerRef = useRef<OverlayScrollbarsComponentRef>(null)
+  const correctScrollContainerRef = useRef<ScrollContainerHandle>(null)
+  const errorScrollContainerRef = useRef<ScrollContainerHandle>(null)
   const { response, correctInfo } = useSpeller()
   const { width } = useWindowSize()
   const isDesktop = width && width >= 1377
@@ -38,26 +38,6 @@ export const SpellerRefsProvider = ({
       )
     : null
 
-  const scrollToElement = (
-    scrollContainer: OverlayScrollbarsComponentRef,
-    targetElement: HTMLDivElement,
-  ) => {
-    const osInstance = scrollContainer?.osInstance()
-    if (!osInstance) return
-
-    const { scrollOffsetElement } = osInstance.elements()
-    const containerRect = scrollOffsetElement.getBoundingClientRect()
-    const targetRect = targetElement.getBoundingClientRect()
-
-    const offsetTop =
-      targetRect.top - containerRect.top + scrollOffsetElement.scrollTop
-
-    scrollOffsetElement.scrollTo({
-      top: offsetTop,
-      behavior: 'smooth',
-    })
-  }
-
   const scrollSection = (target: 'correct' | 'error', index: number) => {
     const refs = target === 'correct' ? correctRefs : errorRefs
     const scrollContainerRef =
@@ -66,10 +46,9 @@ export const SpellerRefsProvider = ({
     if (!refs || !scrollContainerRef.current) return
 
     const targetElement = refs[index]?.current
-    const container = scrollContainerRef.current
 
-    if (targetElement && container) {
-      scrollToElement(container, targetElement)
+    if (targetElement && scrollContainerRef.current) {
+      scrollContainerRef.current.scrollToElement(targetElement)
     }
   }
 

--- a/src/pages/results/ui/correction-content.tsx
+++ b/src/pages/results/ui/correction-content.tsx
@@ -29,7 +29,7 @@ const CorrectionContent = () => {
       <div className='min-w-0 flex-1'>
         <ScrollContainer
           isFocused={isFocused}
-          containerRef={correctScrollContainerRef}
+          ref={correctScrollContainerRef}
           onScrollStatusChange={handleScroll}
           className='h-full min-h-40 flex-1'
         >

--- a/src/pages/results/ui/correction-content.tsx
+++ b/src/pages/results/ui/correction-content.tsx
@@ -5,12 +5,13 @@ import { SpellingCorrectionText } from './spelling-correction-text'
 import { ScrollGradientFade } from '@/shared/ui/scroll-gradient-fade'
 import { ScrollContainer } from '@/shared/ui/scroll-container'
 import { useSpellerRefs } from '@/entities/speller'
+import { useDesktopOrFallback } from '@/shared/lib/use-desktop-or-fallback'
 
 const CorrectionContent = () => {
   const { correctScrollContainerRef } = useSpellerRefs()
-
   const [showGradient, setShowGradient] = useState(false)
   const [isFocused, setIsFocused] = useState(false)
+  const shouldShowFocusState = useDesktopOrFallback(true, isFocused)
 
   const handleScroll = useCallback((isScrolling: boolean) => {
     setShowGradient(isScrolling)
@@ -28,7 +29,7 @@ const CorrectionContent = () => {
       {/* 교정 텍스트 */}
       <div className='min-w-0 flex-1'>
         <ScrollContainer
-          isFocused={isFocused}
+          isFocused={shouldShowFocusState}
           ref={correctScrollContainerRef}
           onScrollStatusChange={handleScroll}
           className='h-full min-h-40 flex-1'

--- a/src/pages/results/ui/error-tracking-section.tsx
+++ b/src/pages/results/ui/error-tracking-section.tsx
@@ -33,7 +33,7 @@ const ErrorTrackingSection = () => {
       </h2>
       <ScrollContainer
         isFocused={isFocused}
-        containerRef={errorScrollContainerRef}
+        ref={errorScrollContainerRef}
         onScrollStatusChange={handleScroll}
         className='-mt-[1.125rem] flex-1'
       >

--- a/src/pages/results/ui/error-tracking-section.tsx
+++ b/src/pages/results/ui/error-tracking-section.tsx
@@ -11,14 +11,15 @@ import { ScrollContainer } from '@/shared/ui/scroll-container'
 import { ScrollGradientFade } from '@/shared/ui/scroll-gradient-fade'
 import { ErrorInfoSection } from './error-info-section'
 import { BulletBadge } from '../ui/bullet-badge'
+import { useDesktopOrFallback } from '@/shared/lib/use-desktop-or-fallback'
 
 const ErrorTrackingSection = () => {
   const { errorRefs, errorScrollContainerRef, scrollSection } = useSpellerRefs()
   const { response } = useSpeller()
   const { errInfo } = response ?? {}
-
   const [showGradient, setShowGradient] = useState(false)
   const [isFocused, setIsFocused] = useState(false)
+  const shouldShowFocusState = useDesktopOrFallback(true, isFocused)
 
   const handleScroll = useCallback((isScrolling: boolean) => {
     setShowGradient(isScrolling)
@@ -27,15 +28,17 @@ const ErrorTrackingSection = () => {
 
   return (
     <>
-      <h2 className='flex items-center gap-1 pb-[1.125rem] text-lg font-semibold leading-[1.9125rem] tracking-[-0.0225rem] tab:text-[1.375rem] tab:leading-[2.3375rem] tab:tracking-[-0.0275rem] pc:text-[1.5rem] pc:leading-[2.55rem] pc:tracking-[-0.03rem]'>
-        맞춤법/문법 오류
-        <span className='text-red-100'>{errInfo.length}개</span>
-      </h2>
+      <div className='mb-[1rem] flex justify-between tab:mb-[1.25rem]'>
+        <h2 className='text-lg font-semibold leading-[1.9125rem] tracking-[-0.0225rem] tab:text-[1.375rem] tab:leading-[2.3375rem] tab:tracking-[-0.0275rem] pc:text-[1.5rem] pc:leading-[2.55rem] pc:tracking-[-0.03rem]'>
+          맞춤법/문법 오류
+          <span className='text-red-100'>{errInfo.length}개</span>
+        </h2>
+      </div>
       <ScrollContainer
-        isFocused={isFocused}
+        isFocused={shouldShowFocusState}
         ref={errorScrollContainerRef}
         onScrollStatusChange={handleScroll}
-        className='-mt-[1.125rem] flex-1'
+        className='flex-1'
       >
         <div>
           {errInfo.map((info, idx) => (

--- a/src/shared/lib/google-ad-sense.tsx
+++ b/src/shared/lib/google-ad-sense.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { cn } from '@/shared/lib/tailwind-merge'
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
+import { useDesktop } from './use-desktop'
 
 declare global {
   interface Window {
@@ -10,20 +11,38 @@ declare global {
 }
 
 interface GoogleAdSenseProps {
-  slot?: string
   className?: string
 }
-const GoogleAdSense = ({ slot, className }: GoogleAdSenseProps) => {
+
+const NO_DELAY = 0 // 화면 크기 전환 시 지연 없이 렌더링하여, 데스크탑 전환 시 발생할 수 있는 느린 레이아웃 쉬프트 방지
+
+const GoogleAdSense = ({ className, ...props }: GoogleAdSenseProps) => {
   const adRef = useRef<HTMLModElement>(null)
+  const [isMounted, setIsMounted] = useState(false)
+  // 데스크탑: 수동 광고 사용
+  // 태블릿/모바일: 자동 광고 사용 (Google이 <ins> 태그 없이 광고 자동 삽입)
+  const isDesktop = useDesktop(NO_DELAY)
 
   useEffect(() => {
-    if (adRef.current) {
-      // 이미 초기화된 광고인지 확인
-      if (!adRef.current.getAttribute('data-adsbygoogle-status')) {
+    setIsMounted(true)
+  }, [])
+
+  useEffect(() => {
+    // 광고 DOM이 렌더된 이후에만 push 실행
+    if (isDesktop && adRef.current) {
+      try {
         ;(window.adsbygoogle = window.adsbygoogle || []).push({})
+      } catch (e) {
+        console.error(e)
       }
     }
-  }, [])
+  }, [isDesktop])
+
+  // 마운트 전에는 아무것도 렌더링하지 않음
+  if (!isMounted) return null
+
+  // 마운트 후 데스크톱이 아니면 렌더링하지 않음
+  if (!isDesktop) return null
 
   if (!process.env.NEXT_PUBLIC_AD_CLIENT) {
     console.error('AdSense client ID is missing.')
@@ -35,9 +54,7 @@ const GoogleAdSense = ({ slot, className }: GoogleAdSenseProps) => {
       ref={adRef}
       className={cn('adsbygoogle', 'block', className)}
       data-ad-client={process.env.NEXT_PUBLIC_AD_CLIENT}
-      data-ad-slot={slot}
-      data-ad-format='auto'
-      data-full-width-responsive='true'
+      {...props}
     />
   )
 }

--- a/src/shared/lib/use-desktop-or-fallback.ts
+++ b/src/shared/lib/use-desktop-or-fallback.ts
@@ -1,0 +1,20 @@
+'use client'
+
+import { useDesktop } from '@/shared/lib/use-desktop'
+import { useMemo } from 'react'
+
+/**
+ * 데스크탑 여부에 따라 지정된 값을 반환하는 훅
+ * @param desktopValue 데스크탑일 경우 반환할 값
+ * @param fallbackValue 아닐 경우 반환할 값
+ */
+const useDesktopOrFallback = <T>(desktopValue: T, fallbackValue: T): T => {
+  const isDesktop = useDesktop()
+  const result = useMemo(() => {
+    return isDesktop ? desktopValue : fallbackValue
+  }, [isDesktop, desktopValue, fallbackValue])
+
+  return result
+}
+
+export { useDesktopOrFallback }

--- a/src/shared/lib/use-desktop.ts
+++ b/src/shared/lib/use-desktop.ts
@@ -1,0 +1,19 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useWindowSize } from '@frontend-opensource/use-react-hooks'
+
+const DELAY_MS = 1000 // 1초
+const DESKTOP_SIZE = 1377 // 데스크탑 너비
+
+const isDesktopWidth = (width: number) => width >= DESKTOP_SIZE
+
+const useDesktop = (delayTime?: number) => {
+  const { width } = useWindowSize(delayTime ?? DELAY_MS)
+  const targetWidth = width ?? 0
+  const isDesktop = useMemo(() => isDesktopWidth(targetWidth), [targetWidth])
+
+  return isDesktop
+}
+
+export { useDesktop }

--- a/src/shared/ui/base-layout.tsx
+++ b/src/shared/ui/base-layout.tsx
@@ -13,8 +13,9 @@ const BaseLayout: FC<PropsWithChildren> = ({ children }) => {
         {/* 광고 영역 */}
         <div className='my-24 hidden rounded-md bg-slate-300 pc:ml-5 pc:block'>
           <GoogleAdSense
-            slot='9725653724'
             className='h-[37.5rem] w-40 place-content-center'
+            data-ad-slot='9725653724'
+            data-full-width-responsive='true'
           />
         </div>
       </div>

--- a/src/shared/ui/footer.tsx
+++ b/src/shared/ui/footer.tsx
@@ -5,7 +5,7 @@ const Footer = () => {
   return (
     <footer className='bg-slate-200 pt-6 pc:py-[1.875rem]'>
       <div className='pc:container pc:mx-auto pc:px-[3.81rem]'>
-        <div className='flex flex-col items-center justify-center pc:flex-row pc:justify-between'>
+        <div className='flex flex-col items-center justify-center tab:min-h-[90px] pc:flex-row pc:justify-between'>
           <div className='flex flex-col items-center gap-1 pb-4 text-[0.625rem] tab:pb-[5.06rem] pc:items-start pc:pb-0'>
             {/* 고객센터 섹션 */}
             <div className='flex gap-2 text-slate-600'>
@@ -63,8 +63,14 @@ const Footer = () => {
               Copyrightⓒ2001 AI Lab & Narainfotech. All Rights Reserved
             </div>
           </div>
-          {/* 광고 영역 */}
-          <GoogleAdSense className='mb-1 w-80 rounded-sm bg-slate-300 p-4 text-center tab:mb-0 tab:w-full pc:w-1/2' />
+          <div className='hidden h-[90px] w-[728px] pc:block'>
+            {/* 광고 영역 */}
+            <GoogleAdSense
+              className='mb-1 hidden h-[50px] w-80 rounded-sm bg-slate-300 p-4 text-center tab:mb-0 tab:h-[90px] tab:w-[728px] pc:block'
+              data-ad-slot='4790060150'
+              data-full-width-responsive='true'
+            />
+          </div>
         </div>
       </div>
     </footer>

--- a/src/shared/ui/scroll-container.tsx
+++ b/src/shared/ui/scroll-container.tsx
@@ -1,11 +1,15 @@
 'use client'
 
-import React, { useEffect, useState, PropsWithChildren } from 'react'
-import {
-  OverlayScrollbarsComponent,
-  OverlayScrollbarsComponentRef,
-  useOverlayScrollbars,
-} from 'overlayscrollbars-react'
+import React, {
+  useRef,
+  useEffect,
+  useState,
+  PropsWithChildren,
+  forwardRef,
+  useImperativeHandle,
+} from 'react'
+import { useOverlayScrollbars } from 'overlayscrollbars-react'
+import { OverlayScrollbars } from 'overlayscrollbars'
 
 import { cn } from '../lib/tailwind-merge'
 import { useClient } from '../lib/use-client'
@@ -13,20 +17,26 @@ import { useOptimizedScrollDetection } from '../lib/use-optimized-scroll-detecti
 
 interface ScrollContainerProps extends React.HTMLAttributes<HTMLDivElement> {
   isFocused?: boolean
-  containerRef?: React.RefObject<OverlayScrollbarsComponentRef> | null
   onScrollStatusChange?: (isScrolling: boolean) => void
 }
 
-const ScrollContainer = ({
-  isFocused,
-  containerRef,
-  children,
-  className,
-  onScrollStatusChange,
-  ...props
-}: PropsWithChildren<ScrollContainerProps>) => {
-  const isClient = useClient()
+export interface ScrollContainerHandle {
+  scrollToElement: (targetElement: HTMLElement) => void
+  scrollTo: (options: ScrollToOptions) => void
+  getScrollPosition: () => { x: number; y: number }
+  getOsInstance: () => OverlayScrollbars | null
+}
 
+const ScrollContainer = forwardRef<
+  ScrollContainerHandle,
+  PropsWithChildren<ScrollContainerProps>
+>(({ isFocused, children, className, onScrollStatusChange, ...props }, ref) => {
+  const isClient = useClient()
+  /**
+   * ⚠️ customScrollBarRef는 내부 컴포넌트와만 연동해야 합니다.
+   * 외부 Ref에 직접 연결하면 정상 동작하지 않습니다.
+   */
+  const customScrollBarRef = useRef<HTMLDivElement>(null)
   const [isScrollVisible, setIsScrollVisible] = useState(false)
   const [visibility, setVisibility] = useState<'visible' | 'hidden'>('visible')
 
@@ -35,13 +45,12 @@ const ScrollContainer = ({
     setIsScrollVisible(status)
   }, 500)
 
-  const [initialize] = useOverlayScrollbars({
+  const [initialize, getInstance] = useOverlayScrollbars({
     options: {
-      paddingAbsolute: true,
       scrollbars: {
+        visibility, // 포커스 상태에 따라 스크롤바 표시/숨김
         theme: 'os-theme-custom',
         autoHide: 'never',
-        visibility, // 포커스 상태에 따라 스크롤바 표시/숨김
         dragScroll: true,
         clickScroll: 'instant',
       },
@@ -55,6 +64,56 @@ const ScrollContainer = ({
     },
     defer: true,
   })
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      scrollTo: options => {
+        const instance = getInstance()
+
+        if (instance) {
+          const elements = instance.elements()
+          const scrollOffsetElement = elements.scrollOffsetElement
+
+          scrollOffsetElement.scrollTo(options)
+        }
+      },
+      scrollToElement: element => {
+        const instance = getInstance()
+
+        if (instance && element) {
+          const elements = instance.elements()
+          const scrollOffsetElement = elements.scrollOffsetElement
+          const containerRect = scrollOffsetElement.getBoundingClientRect()
+          const elementRect = element.getBoundingClientRect()
+          const offsetTop =
+            elementRect.top - containerRect.top + scrollOffsetElement.scrollTop
+
+          scrollOffsetElement.scrollTo({
+            top: offsetTop,
+            behavior: 'smooth',
+          })
+        }
+      },
+      getScrollPosition: () => {
+        const instance = getInstance()
+
+        if (instance) {
+          const elements = instance.elements()
+          const scrollOffsetElement = elements.scrollOffsetElement
+
+          return {
+            x: scrollOffsetElement.scrollLeft,
+            y: scrollOffsetElement.scrollTop,
+          }
+        }
+
+        return { x: 0, y: 0 }
+      },
+      getOsInstance: () => getInstance(),
+    }),
+    [getInstance],
+  )
 
   useEffect(() => {
     // 우선 visible 상태로 설정
@@ -71,23 +130,23 @@ const ScrollContainer = ({
   }, [isScrollVisible, isFocused])
 
   useEffect(() => {
-    if (!isClient) return
-    initialize(document.body)
-  }, [isClient])
+    if (!isClient || !customScrollBarRef?.current) return
+
+    initialize(customScrollBarRef.current)
+  }, [isClient, initialize, getInstance])
 
   return (
-    <OverlayScrollbarsComponent
+    <div
+      ref={customScrollBarRef}
       data-overlayscrollbars-initialize
-      ref={containerRef}
-      className={cn(
-        'mr-[-1.25rem] resize-none overflow-y-auto pr-[1.25rem] outline-none',
-        className,
-      )}
+      className={cn('mr-[-1.25rem] pr-[1.25rem]', className)}
       {...props}
     >
       {children}
-    </OverlayScrollbarsComponent>
+    </div>
   )
-}
+})
+
+ScrollContainer.displayName = 'CustomScrollContainer'
 
 export { ScrollContainer }

--- a/src/shared/ui/scroll-container.tsx
+++ b/src/shared/ui/scroll-container.tsx
@@ -27,6 +27,8 @@ export interface ScrollContainerHandle {
   getOsInstance: () => OverlayScrollbars | null
 }
 
+const SCROLL_VISIBILITY_DELAY = 500
+
 const ScrollContainer = forwardRef<
   ScrollContainerHandle,
   PropsWithChildren<ScrollContainerProps>
@@ -43,7 +45,7 @@ const ScrollContainer = forwardRef<
   const handleScroll = useOptimizedScrollDetection(status => {
     onScrollStatusChange?.(status)
     setIsScrollVisible(status)
-  }, 500)
+  }, SCROLL_VISIBILITY_DELAY)
 
   const [initialize, getInstance] = useOverlayScrollbars({
     options: {
@@ -124,7 +126,7 @@ const ScrollContainer = forwardRef<
       if (!isScrollVisible && !isFocused) {
         setVisibility('hidden')
       }
-    }, 500)
+    }, SCROLL_VISIBILITY_DELAY)
 
     return () => clearTimeout(timer)
   }, [isScrollVisible, isFocused])
@@ -133,7 +135,7 @@ const ScrollContainer = forwardRef<
     if (!isClient || !customScrollBarRef?.current) return
 
     initialize(customScrollBarRef.current)
-  }, [isClient, initialize, getInstance])
+  }, [isClient, initialize])
 
   return (
     <div

--- a/src/shared/ui/textarea.tsx
+++ b/src/shared/ui/textarea.tsx
@@ -6,6 +6,7 @@ import { initCaretPositionPolyfill } from '@/shared/lib/caret-position.polyfill'
 import { ScrollContainer } from './scroll-container'
 import { useClient } from '../lib/use-client'
 import { cn } from '../lib/tailwind-merge'
+import { useDesktopOrFallback } from '../lib/use-desktop-or-fallback'
 
 if (typeof window !== 'undefined') {
   initCaretPositionPolyfill()
@@ -30,6 +31,7 @@ const Textarea: FC<TextareaProps> = ({
 }) => {
   const isClient = useClient()
   const [isFocused, setIsFocused] = useState(false)
+  const shouldShowFocusState = useDesktopOrFallback(true, isFocused)
   // 실제 편집 가능한 텍스트 영역 요소 참조
   const contentEditableRef = useRef<HTMLDivElement>(null)
   // 마지막으로 업데이트된 값을 저장 (불필요한 리렌더링 방지)
@@ -129,7 +131,7 @@ const Textarea: FC<TextareaProps> = ({
     <ScrollContainer
       suppressHydrationWarning
       suppressContentEditableWarning
-      isFocused={isFocused}
+      isFocused={shouldShowFocusState}
       onScrollStatusChange={onScroll}
       className='h-full min-h-40 flex-1'
     >


### PR DESCRIPTION
PR 목적

이번 PR은 다음 두 가지 목적을 갖고 있습니다:

1. **OverlayScrollbars 기반 커스텀 스크롤바 컴포넌트 기능 추가**
2. **외부에서 컴포넌트를 사용할 때 발생하는 Ref 동기화 문제 개선**

해당 컴포넌트는 공통 UI 요소로 사용되며, 여러 페이지에서 재사용될 예정입니다.  
특히 외부에서 스크롤을 직접 제어할 경우 발생할 수 있는 제약 사항과 그 해결 방법을 문서화하였습니다.

---

변경 배경

- 초기에는 `textarea` 전용 커스텀 스크롤 컴포넌트로 개발되었습니다.
- 이후 공통 UI로 확장되면서 외부 Ref 연동이 필요해졌습니다.
- 그러나 `OverlayScrollbars`는 초기화 시 DOM 구조를 래핑하고, 네이티브 스크롤 메서드를 오버라이드합니다.
- 기존 방식으로는 외부에서 내부 API에 접근이 불가능하여, 세밀한 스크롤 제어를 위한 API 노출이 필요했습니다.

---

주요 문제점

| 문제 | 설명 |
|------|------|
| Ref 연결 실패 | 외부에서 `ref.current.scrollTo()` 호출 시 동작하지 않음 |
| 스크롤 위치 제어 불가 | DOM이 래핑되어 `scrollTop`, `scrollTo` 방식이 작동하지 않음 |
| 동기화 타이밍 이슈 | `OverlayScrollbars` 초기화 이후 `Ref`가 올바르게 매핑되지 않음 |
| API 사용 충돌 | `OverlayScrollbarsComponent`와 `useOverlayScrollbars`를 동시에 사용하면 비정상 동작 |
| 중첩 스크롤 이슈 | `overflow-y-auto`와 OverlayScrollbars 스타일이 충돌하여 이중 스크롤 가능성 발생 |

---

왜 `scrollIntoView()`는 작동했는가?

- `scrollIntoView()`는 브라우저의 **네이티브 API**로, DOM 구조에 관계없이 요소를 뷰포트 내로 이동시킵니다.
- 이는 `OverlayScrollbars`의 내부 구현과 무관하게 정상 작동합니다.
- 반면, `scrollTo`, `scrollBy` 등은 OverlayScrollbars가 자체적으로 오버라이드하고 있어, 일반 `Ref` 접근 방식으로는 제어할 수 없습니다.

---

해결 방법: `useImperativeHandle` 활용

- 외부에서 안전하게 사용할 수 있는 제어 메서드(API)만 명시적으로 노출하였습니다.
- 내부 DOM 구조에 직접 접근하지 않아도 스크롤을 제어할 수 있습니다.
- 타입 기반 API를 통해 안정성과 재사용성을 보장합니다.

---

바뀐 API를 직접 수정해야 하나요?

- **아닙니다.** 해당 PR은 공통 컴포넌트의 내부 구현을 개선한 것으로, 사용하는 쪽에서 로직을 대부분 유지할 수 있도록 구성했습니다.
- 다만, 기존에 직접 Ref로 스크롤을 제어하던 경우에는, 새로 노출된 API 방식으로 일부 변경이 필요할 수 있습니다.
- 관련된 컴포넌트는 확인 후 직접 적용 및 테스트를 완료하였으며, 브랜치를 전환하여 확인해주시면 감사하겠습니다.