### PR TITLE
[#158] 스크롤바가 PC에서는 항상 보이게 수정

### DIFF
--- a/src/entities/speller/model/speller-refs-context.tsx
+++ b/src/entities/speller/model/speller-refs-context.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { createContext, useContext, createRef, useRef } from 'react'
-import { useWindowSize } from '@frontend-opensource/use-react-hooks'
 import { useSpeller } from './use-speller'
 import { ScrollContainerHandle } from '@/shared/ui/scroll-container'
+import { useDesktop } from '@/shared/lib/use-desktop'
 
 interface SpellerRefsContextType {
   correctRefs: React.RefObject<HTMLDivElement>[] | null
@@ -23,8 +23,7 @@ export const SpellerRefsProvider = ({
   const correctScrollContainerRef = useRef<ScrollContainerHandle>(null)
   const errorScrollContainerRef = useRef<ScrollContainerHandle>(null)
   const { response, correctInfo } = useSpeller()
-  const { width } = useWindowSize()
-  const isDesktop = width && width >= 1377
+  const isDesktop = useDesktop()
 
   const correctRefs = isDesktop
     ? Array.from({ length: Object.keys(correctInfo).length }, () =>

--- a/src/pages/results/ui/correction-content.tsx
+++ b/src/pages/results/ui/correction-content.tsx
@@ -5,12 +5,13 @@ import { SpellingCorrectionText } from './spelling-correction-text'
 import { ScrollGradientFade } from '@/shared/ui/scroll-gradient-fade'
 import { ScrollContainer } from '@/shared/ui/scroll-container'
 import { useSpellerRefs } from '@/entities/speller'
+import { useDesktopOrFallback } from '@/shared/lib/use-desktop-or-fallback'
 
 const CorrectionContent = () => {
   const { correctScrollContainerRef } = useSpellerRefs()
-
   const [showGradient, setShowGradient] = useState(false)
   const [isFocused, setIsFocused] = useState(false)
+  const shouldShowFocusState = useDesktopOrFallback(true, isFocused)
 
   const handleScroll = useCallback((isScrolling: boolean) => {
     setShowGradient(isScrolling)
@@ -28,7 +29,7 @@ const CorrectionContent = () => {
       {/* 교정 텍스트 */}
       <div className='min-w-0 flex-1'>
         <ScrollContainer
-          isFocused={isFocused}
+          isFocused={shouldShowFocusState}
           ref={correctScrollContainerRef}
           onScrollStatusChange={handleScroll}
           className='h-full min-h-40 flex-1'

--- a/src/pages/results/ui/error-tracking-section.tsx
+++ b/src/pages/results/ui/error-tracking-section.tsx
@@ -11,14 +11,15 @@ import { ScrollContainer } from '@/shared/ui/scroll-container'
 import { ScrollGradientFade } from '@/shared/ui/scroll-gradient-fade'
 import { ErrorInfoSection } from './error-info-section'
 import { BulletBadge } from '../ui/bullet-badge'
+import { useDesktopOrFallback } from '@/shared/lib/use-desktop-or-fallback'
 
 const ErrorTrackingSection = () => {
   const { errorRefs, errorScrollContainerRef, scrollSection } = useSpellerRefs()
   const { response } = useSpeller()
   const { errInfo } = response ?? {}
-
   const [showGradient, setShowGradient] = useState(false)
   const [isFocused, setIsFocused] = useState(false)
+  const shouldShowFocusState = useDesktopOrFallback(true, isFocused)
 
   const handleScroll = useCallback((isScrolling: boolean) => {
     setShowGradient(isScrolling)
@@ -32,7 +33,7 @@ const ErrorTrackingSection = () => {
         <span className='text-red-100'>{errInfo.length}개</span>
       </h2>
       <ScrollContainer
-        isFocused={isFocused}
+        isFocused={shouldShowFocusState}
         ref={errorScrollContainerRef}
         onScrollStatusChange={handleScroll}
         className='-mt-[1.125rem] flex-1'

--- a/src/pages/results/ui/error-tracking-section.tsx
+++ b/src/pages/results/ui/error-tracking-section.tsx
@@ -28,15 +28,17 @@ const ErrorTrackingSection = () => {
 
   return (
     <>
-      <h2 className='flex items-center gap-1 pb-[1.125rem] text-lg font-semibold leading-[1.9125rem] tracking-[-0.0225rem] tab:text-[1.375rem] tab:leading-[2.3375rem] tab:tracking-[-0.0275rem] pc:text-[1.5rem] pc:leading-[2.55rem] pc:tracking-[-0.03rem]'>
-        맞춤법/문법 오류
-        <span className='text-red-100'>{errInfo.length}개</span>
-      </h2>
+      <div className='mb-[1rem] flex justify-between tab:mb-[1.25rem]'>
+        <h2 className='text-lg font-semibold leading-[1.9125rem] tracking-[-0.0225rem] tab:text-[1.375rem] tab:leading-[2.3375rem] tab:tracking-[-0.0275rem] pc:text-[1.5rem] pc:leading-[2.55rem] pc:tracking-[-0.03rem]'>
+          맞춤법/문법 오류
+          <span className='text-red-100'>{errInfo.length}개</span>
+        </h2>
+      </div>
       <ScrollContainer
         isFocused={shouldShowFocusState}
         ref={errorScrollContainerRef}
         onScrollStatusChange={handleScroll}
-        className='-mt-[1.125rem] flex-1'
+        className='flex-1'
       >
         <div>
           {errInfo.map((info, idx) => (

--- a/src/shared/lib/google-ad-sense.tsx
+++ b/src/shared/lib/google-ad-sense.tsx
@@ -14,14 +14,14 @@ interface GoogleAdSenseProps {
   className?: string
 }
 
-const DELAY_MS = 0 // 화면 크기 전환 시 지연 없이 렌더링하여, 데스크탑 전환 시 발생할 수 있는 느린 레이아웃 쉬프트 방지
+const NO_DELAY = 0 // 화면 크기 전환 시 지연 없이 렌더링하여, 데스크탑 전환 시 발생할 수 있는 느린 레이아웃 쉬프트 방지
 
 const GoogleAdSense = ({ className, ...props }: GoogleAdSenseProps) => {
   const adRef = useRef<HTMLModElement>(null)
   const [isMounted, setIsMounted] = useState(false)
   // 데스크탑: 수동 광고 사용
   // 태블릿/모바일: 자동 광고 사용 (Google이 <ins> 태그 없이 광고 자동 삽입)
-  const isDesktop = useDesktop(DELAY_MS)
+  const isDesktop = useDesktop(NO_DELAY)
 
   useEffect(() => {
     setIsMounted(true)

--- a/src/shared/lib/google-ad-sense.tsx
+++ b/src/shared/lib/google-ad-sense.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useDeviceUtils } from '@/shared/lib/use-device-utils'
 import { cn } from '@/shared/lib/tailwind-merge'
 import React, { useEffect, useRef, useState } from 'react'
+import { useDesktop } from './use-desktop'
 
 declare global {
   interface Window {
@@ -13,30 +13,36 @@ declare global {
 interface GoogleAdSenseProps {
   className?: string
 }
+
+const DELAY_MS = 0 // 화면 크기 전환 시 지연 없이 렌더링하여, 데스크탑 전환 시 발생할 수 있는 느린 레이아웃 쉬프트 방지
+
 const GoogleAdSense = ({ className, ...props }: GoogleAdSenseProps) => {
   const adRef = useRef<HTMLModElement>(null)
-
+  const [isMounted, setIsMounted] = useState(false)
   // 데스크탑: 수동 광고 사용
   // 태블릿/모바일: 자동 광고 사용 (Google이 <ins> 태그 없이 광고 자동 삽입)
-  const { isDesktop } = useDeviceUtils()
-  const [isDesktopView, setIsDesktopView] = useState(false)
+  const isDesktop = useDesktop(DELAY_MS)
 
   useEffect(() => {
-    setIsDesktopView(isDesktop)
-  }, [isDesktop])
+    setIsMounted(true)
+  }, [])
 
   useEffect(() => {
     // 광고 DOM이 렌더된 이후에만 push 실행
-    if (isDesktopView && adRef.current) {
+    if (isDesktop && adRef.current) {
       try {
         ;(window.adsbygoogle = window.adsbygoogle || []).push({})
       } catch (e) {
         console.error(e)
       }
     }
-  }, [isDesktopView])
+  }, [isDesktop])
 
-  if (!isDesktopView) return null
+  // 마운트 전에는 아무것도 렌더링하지 않음
+  if (!isMounted) return null
+
+  // 마운트 후 데스크톱이 아니면 렌더링하지 않음
+  if (!isDesktop) return null
 
   if (!process.env.NEXT_PUBLIC_AD_CLIENT) {
     console.error('AdSense client ID is missing.')

--- a/src/shared/lib/isDesktop.ts
+++ b/src/shared/lib/isDesktop.ts
@@ -1,4 +1,0 @@
-const DESKTOP_SIZE = 1377 // 데스크탑 너비
-const isDesktopWidth = (width: number) => width >= DESKTOP_SIZE
-
-export { isDesktopWidth }

--- a/src/shared/lib/isDesktop.ts
+++ b/src/shared/lib/isDesktop.ts
@@ -1,0 +1,4 @@
+const DESKTOP_SIZE = 1377 // 데스크탑 너비
+const isDesktopWidth = (width: number) => width >= DESKTOP_SIZE
+
+export { isDesktopWidth }

--- a/src/shared/lib/use-desktop-or-fallback.ts
+++ b/src/shared/lib/use-desktop-or-fallback.ts
@@ -10,7 +10,6 @@ import { useMemo } from 'react'
  */
 const useDesktopOrFallback = <T>(desktopValue: T, fallbackValue: T): T => {
   const isDesktop = useDesktop()
-
   const result = useMemo(() => {
     return isDesktop ? desktopValue : fallbackValue
   }, [isDesktop, desktopValue, fallbackValue])

--- a/src/shared/lib/use-desktop-or-fallback.ts
+++ b/src/shared/lib/use-desktop-or-fallback.ts
@@ -1,0 +1,21 @@
+'use client'
+
+import { useDesktop } from '@/shared/lib/use-desktop'
+import { useMemo } from 'react'
+
+/**
+ * 데스크탑 여부에 따라 지정된 값을 반환하는 훅
+ * @param desktopValue 데스크탑일 경우 반환할 값
+ * @param fallbackValue 아닐 경우 반환할 값
+ */
+const useDesktopOrFallback = <T>(desktopValue: T, fallbackValue: T): T => {
+  const isDesktop = useDesktop()
+
+  const result = useMemo(() => {
+    return isDesktop ? desktopValue : fallbackValue
+  }, [isDesktop, desktopValue, fallbackValue])
+
+  return result
+}
+
+export { useDesktopOrFallback }

--- a/src/shared/lib/use-desktop.ts
+++ b/src/shared/lib/use-desktop.ts
@@ -1,0 +1,18 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useWindowSize } from '@frontend-opensource/use-react-hooks'
+
+import { isDesktopWidth } from './isDesktop'
+
+const DELAY_MS = 1000 // 1분
+
+const useDesktop = (delayTime?: number) => {
+  const { width } = useWindowSize(delayTime ?? DELAY_MS)
+  const targetWidth = width ?? 0
+  const isDesktop = useMemo(() => isDesktopWidth(targetWidth), [targetWidth])
+
+  return isDesktop
+}
+
+export { useDesktop }

--- a/src/shared/lib/use-desktop.ts
+++ b/src/shared/lib/use-desktop.ts
@@ -3,9 +3,10 @@
 import { useMemo } from 'react'
 import { useWindowSize } from '@frontend-opensource/use-react-hooks'
 
-import { isDesktopWidth } from './isDesktop'
-
 const DELAY_MS = 1000 // 1초
+const DESKTOP_SIZE = 1377 // 데스크탑 너비
+
+const isDesktopWidth = (width: number) => width >= DESKTOP_SIZE
 
 const useDesktop = (delayTime?: number) => {
   const { width } = useWindowSize(delayTime ?? DELAY_MS)

--- a/src/shared/lib/use-desktop.ts
+++ b/src/shared/lib/use-desktop.ts
@@ -5,7 +5,7 @@ import { useWindowSize } from '@frontend-opensource/use-react-hooks'
 
 import { isDesktopWidth } from './isDesktop'
 
-const DELAY_MS = 1000 // 1분
+const DELAY_MS = 1000 // 1초
 
 const useDesktop = (delayTime?: number) => {
   const { width } = useWindowSize(delayTime ?? DELAY_MS)

--- a/src/shared/lib/use-device-utils.ts
+++ b/src/shared/lib/use-device-utils.ts
@@ -1,7 +1,0 @@
-import { useWindowSize } from '@frontend-opensource/use-react-hooks'
-
-export const useDeviceUtils = () => {
-  const { width } = useWindowSize()
-
-  return { isDesktop: width! >= 1377 }
-}

--- a/src/shared/ui/textarea.tsx
+++ b/src/shared/ui/textarea.tsx
@@ -6,6 +6,7 @@ import { initCaretPositionPolyfill } from '@/shared/lib/caret-position.polyfill'
 import { ScrollContainer } from './scroll-container'
 import { useClient } from '../lib/use-client'
 import { cn } from '../lib/tailwind-merge'
+import { useDesktopOrFallback } from '../lib/use-desktop-or-fallback'
 
 if (typeof window !== 'undefined') {
   initCaretPositionPolyfill()
@@ -30,6 +31,7 @@ const Textarea: FC<TextareaProps> = ({
 }) => {
   const isClient = useClient()
   const [isFocused, setIsFocused] = useState(false)
+  const shouldShowFocusState = useDesktopOrFallback(true, isFocused)
   // 실제 편집 가능한 텍스트 영역 요소 참조
   const contentEditableRef = useRef<HTMLDivElement>(null)
   // 마지막으로 업데이트된 값을 저장 (불필요한 리렌더링 방지)
@@ -129,7 +131,7 @@ const Textarea: FC<TextareaProps> = ({
     <ScrollContainer
       suppressHydrationWarning
       suppressContentEditableWarning
-      isFocused={isFocused}
+      isFocused={shouldShowFocusState}
       onScrollStatusChange={onScroll}
       className='h-full min-h-40 flex-1'
     >


### PR DESCRIPTION
작업내용

데스크탑 너비에서 스크롤이 항상 보이도록 개선하고, 관련된 로직을 재사용 가능한 훅으로 분리하여 최적화하였습니다.


https://github.com/user-attachments/assets/70d5a91d-394a-4041-bc17-714636eac692



--- 

변경사항
- 데스크탑 너비에서 스크롤이 항상 활성화되도록 로직 추가
- 원문 / 교정문서 / 맞춤법 오류 섹션에 너비 기반 상태를 반환하는 재사용 훅 작성
- 데스크탑 여부를 판별하는 훅(useDesktop)에 1초 지연(delay)을 통한 최적화 적용
- 데스크탑 여부에 따라 다른 값을 반환하는 훅(useDesktopOrFallback)에 useMemo를 적용해 불필요한 렌더링 방지