### PR TITLE
[#164] 복사 후 붙여넣기 시 HTML 요소가 포함되는 이슈 수정

### DIFF
--- a/src/pages/feedback/ui/feedback-form.tsx
+++ b/src/pages/feedback/ui/feedback-form.tsx
@@ -37,11 +37,10 @@ const FeedbackForm = () => {
       <div className='mt-2 flex flex-col gap-3 pc:mt-[1.125rem] pc:grid pc:grid-cols-[9.25rem_1fr] pc:gap-0'>
         <FormLabel htmlFor='description' label='문의 내용' />
         <div
-          className='flex h-full max-h-[13.75rem] w-full flex-col rounded-lg bg-white px-5 py-4 pc:max-h-[21.25rem] pc:min-h-[21.25rem]'
+          className='flex h-full max-h-[13.75rem] min-h-56 w-full flex-col rounded-lg bg-white px-5 py-4 pc:max-h-[21.25rem] pc:min-h-[21.25rem]'
           id='description'
         >
           <Textarea
-            value={content}
             name='feedback-text'
             onChange={text => setContent(text)}
             placeholder='내용을 입력해 주세요.'

--- a/src/pages/speller/ui/speller-control.tsx
+++ b/src/pages/speller/ui/speller-control.tsx
@@ -1,15 +1,15 @@
 'use client'
 
-import React, { FC } from 'react'
+import React from 'react'
 
 import { Button } from '@/shared/ui/button'
 import { TextCounter } from '@/shared/ui/text-counter'
+import { useSpeller } from '@/entities/speller'
 
-interface SpellerControlProps {
-  count: number
-}
+const SpellerControl = () => {
+  const { text } = useSpeller()
 
-const SpellerControl: FC<SpellerControlProps> = ({ count }) => {
+  const count = text.length
   const isButtonDisabled = count <= 0
 
   return (

--- a/src/pages/speller/ui/speller-page.tsx
+++ b/src/pages/speller/ui/speller-page.tsx
@@ -13,8 +13,7 @@ import { SpellerControl } from './speller-control'
 
 const SpellerPage = () => {
   const router = useRouter()
-  const { text, handleTextChange, handleReceiveResponse, initResponseMap } =
-    useSpeller()
+  const { handleReceiveResponse, initResponseMap } = useSpeller()
   const [state, formAction, isPending] = useActionState(spellCheckAction, {
     data: null,
     error: null,
@@ -67,9 +66,9 @@ const SpellerPage = () => {
           <SpellerSetting />
         </div>
         <div className='flex h-full w-full flex-col rounded-lg bg-white p-5 tab:rounded-[1rem] tab:p-10 pc:max-h-[40.25rem]'>
-          <SpellerTextInput text={text} onTextChange={handleTextChange} />
+          <SpellerTextInput />
           {/* 글자수 & 검사하기 버튼 */}
-          <SpellerControl count={text.length} />
+          <SpellerControl />
         </div>
       </ContentLayout>
     </form>

--- a/src/pages/speller/ui/speller-text-input.tsx
+++ b/src/pages/speller/ui/speller-text-input.tsx
@@ -1,26 +1,33 @@
 'use client'
 
-import React, { FC, useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 
-import { Textarea } from '@/shared/ui/textarea'
+import { Textarea, TextareaHandle } from '@/shared/ui/textarea'
 import { ClearTextButton } from './clear-text-button'
 import { ScrollGradientFade } from '@/shared/ui/scroll-gradient-fade'
+import { useSpeller } from '@/entities/speller'
 
-interface SpellerTextInputProps {
-  text: string
-  onTextChange: (value: string) => void
-}
-
-const SpellerTextInput: FC<SpellerTextInputProps> = ({
-  onTextChange,
-  text,
-}) => {
+const SpellerTextInput = () => {
+  const textareaRef = useRef<TextareaHandle>(null)
+  const { handleTextChange, text } = useSpeller()
   const [showGradient, setShowGradient] = useState(false)
-  const handleOnClear = useCallback(() => onTextChange(''), [])
+
+  const handleOnClear = useCallback(() => {
+    if (textareaRef.current) {
+      textareaRef.current.textClear()
+    }
+  }, [])
+
   const handleScroll = useCallback(
     (isScrolling: boolean) => setShowGradient(isScrolling),
     [],
   )
+
+  useEffect(() => {
+    if (!textareaRef.current) return
+
+    textareaRef.current.hydrateText(text)
+  }, [])
 
   return (
     <>
@@ -33,9 +40,9 @@ const SpellerTextInput: FC<SpellerTextInputProps> = ({
       {/* 텍스트 입력 */}
       <div className='min-w-0 flex-1'>
         <Textarea
-          value={text}
+          ref={textareaRef}
           name='speller-text'
-          onChange={onTextChange}
+          onChange={handleTextChange}
           onScroll={handleScroll}
           placeholder='내용을 입력해 주세요.'
         />

--- a/src/shared/ui/textarea.tsx
+++ b/src/shared/ui/textarea.tsx
@@ -1,157 +1,93 @@
 'use client'
 
-import { FC, useEffect, useRef, useState } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
-import { initCaretPositionPolyfill } from '@/shared/lib/caret-position.polyfill'
 import { ScrollContainer } from './scroll-container'
-import { useClient } from '../lib/use-client'
 import { cn } from '../lib/tailwind-merge'
 
-if (typeof window !== 'undefined') {
-  initCaretPositionPolyfill()
+export interface TextareaHandle {
+  textClear: () => void
+  hydrateText: (payload: string) => void
 }
 
 interface TextareaProps {
-  value: string
   placeholder: string
+  onChange: (value: string) => void
   name?: string
   className?: React.HTMLAttributes<HTMLDivElement>['className']
-  onChange: (value: string) => void
   onScroll?: (isScrolling: boolean) => void
 }
 
-const Textarea: FC<TextareaProps> = ({
-  onChange,
-  value,
-  placeholder,
-  onScroll,
-  name,
-  className,
-}) => {
-  const isClient = useClient()
-  const [isFocused, setIsFocused] = useState(false)
-  // 실제 편집 가능한 텍스트 영역 요소 참조
-  const contentEditableRef = useRef<HTMLDivElement>(null)
-  // 마지막으로 업데이트된 값을 저장 (불필요한 리렌더링 방지)
-  const lastValueRef = useRef('')
+const Textarea = forwardRef<TextareaHandle, TextareaProps>(
+  ({ className, onScroll, onChange, placeholder, name }, ref) => {
+    const [isFocused, setIsFocused] = useState(false)
+    const textareaRef = useRef<HTMLTextAreaElement>(null)
 
-  // value prop이 외부에서 변경될 때 동기화
-  useEffect(() => {
-    if (!isClient || !contentEditableRef.current) return
+    const syncTextareaHeight = () => {
+      const textarea = textareaRef.current
 
-    if (value !== lastValueRef.current) {
-      contentEditableRef.current.innerHTML = value
-      lastValueRef.current = value
-    }
-  }, [isClient, value])
+      if (!textarea) return
 
-  const handleInput = (event: React.FormEvent<HTMLDivElement>) => {
-    const content = event.currentTarget
-    const text = convertHtmlToLineBreaks(content.innerHTML)
-
-    lastValueRef.current = text
-    onChange(text)
-
-    // 빈 텍스트일 때 <br> 태그 제거
-    if (!text && content.innerHTML === '<br>') {
-      content.innerHTML = ''
-    }
-  }
-
-  // 포커스 해제 시 처리
-  const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
-    setIsFocused(false)
-
-    // 빈 텍스트일 때 정리
-    if (
-      !event.currentTarget.textContent &&
-      event.currentTarget.innerHTML === '<br>'
-    ) {
-      event.currentTarget.innerHTML = ''
-      lastValueRef.current = ''
-      onChange('')
-    }
-  }
-
-  // 붙여넣기 처리
-  const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    const text = e.clipboardData.getData('text')
-    const selection = window.getSelection()
-
-    if (selection?.rangeCount) {
-      const range = selection.getRangeAt(0)
-      range.deleteContents()
-      range.insertNode(document.createTextNode(text))
-    }
-
-    // 커서를 삽입된 텍스트 끝으로 이동
-    if (contentEditableRef.current) {
-      const newRange = document.createRange()
-      const lastChild =
-        contentEditableRef.current.lastChild || contentEditableRef.current
-      newRange.selectNodeContents(lastChild)
-      newRange.collapse(false)
-      selection?.removeAllRanges()
-      selection?.addRange(newRange)
-    }
-
-    // 상태 업데이트
-    if (contentEditableRef.current) {
-      const text = convertHtmlToLineBreaks(contentEditableRef.current.innerHTML)
-      // 태그 소각
-      const decodedText =
-        new DOMParser().parseFromString(text, 'text/html').documentElement
-          .textContent || ''
-
-      lastValueRef.current = text
-      onChange(text)
-
-      // 빈 텍스트일 때 <br> 태그 제거
-      if (!decodedText && contentEditableRef.current.innerHTML === '<br>') {
-        contentEditableRef.current.innerHTML = ''
+      if (textarea.value.length <= 0) {
+        textarea.style.height = '100%'
+      } else {
+        textarea.style.height = `${textarea.scrollHeight}px`
       }
     }
-  }
 
-  const convertHtmlToLineBreaks = (innerHTML: string) => {
-    const text = innerHTML
-      .replace(/<div><br><\/div>/g, '\n')
-      .replace(/<div>/g, '\n')
-      .replace(/<\/div>/g, '')
-      .replace(/<br>/g, '')
-      .replace(/&nbsp;/g, ' ')
+    const setTextareaValue = (value: string) => {
+      if (!textareaRef.current) return
 
-    return text
-  }
+      textareaRef.current.value = value
+    }
 
-  return (
-    <ScrollContainer
-      suppressHydrationWarning
-      suppressContentEditableWarning
-      isFocused={isFocused}
-      onScrollStatusChange={onScroll}
-      className='h-full min-h-40 flex-1'
-    >
-      <div
-        ref={contentEditableRef}
-        data-placeholder={placeholder}
-        className={cn(
-          'h-0 min-h-full w-full whitespace-pre-wrap break-all text-justify text-[1.125rem] font-normal leading-[1.8rem] tracking-[-0.0225rem] text-slate-600 outline-none empty:before:text-slate-300 empty:before:content-[attr(data-placeholder)] tab:leading-[1.9125rem] pc:text-[1.25rem] pc:leading-[2.125rem] pc:tracking-[-0.025rem]',
-          className,
-        )}
-        contentEditable
-        suppressContentEditableWarning
-        suppressHydrationWarning
-        onFocus={() => setIsFocused(true)}
-        onInput={handleInput}
-        onBlur={handleBlur}
-        onPaste={handlePaste}
-      />
-      <input type='hidden' name={name} value={value} />
-    </ScrollContainer>
-  )
-}
-Textarea.displayName = 'Textarea'
+    useImperativeHandle(
+      ref,
+      () => ({
+        textClear: () => {
+          if (!textareaRef.current) return
+
+          onChange('')
+          setTextareaValue('')
+          syncTextareaHeight()
+        },
+        hydrateText: payload => {
+          setTextareaValue(payload)
+          syncTextareaHeight()
+        },
+      }),
+      [onChange],
+    )
+
+    return (
+      <div className='relative h-full'>
+        <ScrollContainer
+          isFocused={isFocused}
+          onScrollStatusChange={onScroll}
+          className='absolute inset-0 overflow-hidden'
+        >
+          <textarea
+            ref={textareaRef}
+            name={name}
+            style={{ height: '100%' }}
+            placeholder={placeholder}
+            className={cn(
+              'flex h-full w-full resize-none overflow-hidden whitespace-pre-wrap break-all border-none border-input text-justify align-top text-[1.125rem] text-base font-normal leading-[1.8rem] tracking-[-0.0225rem] text-slate-600 ring-offset-background placeholder:text-muted-foreground placeholder:text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 tab:leading-[1.9125rem] pc:text-[1.25rem] pc:leading-[2.125rem] pc:tracking-[-0.025rem]',
+              className,
+            )}
+            onBlur={() => setIsFocused(false)}
+            onFocus={() => setIsFocused(true)}
+            onInput={({ currentTarget: { value } }) => {
+              onChange(value)
+              syncTextareaHeight()
+            }}
+          />
+        </ScrollContainer>
+      </div>
+    )
+  },
+)
+
+Textarea.displayName = 'CustomScrollTextarea'
 
 export { Textarea }


### PR DESCRIPTION
PR 목적

이번 PR은 다음 목적을 갖고 있습니다:

1. **Textarea 회귀 결정 및 브라우저 간 이벤트 처리 이슈 대응**
2. **ContentEditable 방식에서 발생한 유지보수 이슈 해소 및 UX 안정성 확보**
3. **useEffect 최소화 처리**

---

변경 배경

초기에는 커스텀 스크롤이 필요한 상황에서 `div[contentEditable]`을 활용하여 textarea와 유사한 UX를 구현했습니다.  
하지만 플랫폼 및 브라우저 간 복잡한 이슈와 버그가 발생했고, 다음과 같은 이유로 **textarea 방식으로 회귀**하게 되었습니다.

---

주요 문제점

### 1. 브라우저/플랫폼별 붙여넣기 이벤트 차이

| 플랫폼 | 브라우저 | 이벤트 종류 | 동작 여부 |
|--------|----------|-------------|------------|
| Mac    | Safari   | `onPaste`   | 정상 동작 |
|        | Chrome   | `onPaste`   | 정상 동작 |
|        | Edge     | `onPaste`   | 정상 동작 |
| Windows| Chrome   | `onPaste`   | 정상 동작 |
|        | Edge     | `onPaste`   | 정상 동작 |
| iOS    | Chrome   | `onPaste`   | 정상 동작 |
|        | Safari   | `onPaste`   | 정상 동작 |
| Android| Chrome   | ❗ `onInput` | `onPaste` 작동 안함, `innerHTML` 포함 |
|        | 삼성 브라우저 | ❗ `onInput` | 동일 문제 발생 |

> 📌 **Android에서는 `onPaste`가 아예 호출되지 않고 `onInput`으로 대체됨.**  
> 기존 HTML 태그 소각 로직이 작동하지 않음 → **공통 HTML 소각 처리 방식 필요**

---

2. `contentEditable` 기반 커스텀 구성 시 발생한 문제들

| 문제 | 설명 |
|------|------|
| ❌ 커서 드래그 불가 | 같은 텍스트 영역에서 드래그 시도시 드래그 안됨 |
| ❌ 텍스트 뒤로 가기 시 텍스트 복원 실패 | 상태 동기화 어려움 |
| ❌ HTML 태그 소각 실패 | 특히 Android의 `onInput` |
| ❌ 복잡한 이벤트 처리 및 DOM 제어 | 예측 불가한 버그 유발 |
| ❌ 유지보수 난이도 상승 | UX 재현 비용 과다 |

---

4. 문제 재정의: 프로젝트 요구사항을 고려했을때 리치텍스트는 필요없음

- 붙여넣기 시 HTML 태그는 **소각**되어야 함
- 포맷팅, 스타일링, 이미지 등은 **불필요**
- **순수 텍스트 필드**가 본질적 목적

따라서 `textarea`의 기본 동작이 정확히 목적에 부합

---

기존에는 커스텀 스크롤 라이브러리가 `textarea`를 지원하지 않아 `contentEditable` 방식 강제됨  
→ 이제는 호환가능한 **커스텀 `ScrollContainer` 구현**으로 해당 제약 해소

5. 전환 후 발생한 이슈 및 해결

- 문제: `textarea`와 `ScrollContainer`가 각각 스크롤 생성
- 해결:
  - `textareaRef`로 `scrollHeight` 추적
  - `ScrollContainer`가 textarea 높이 동기화 → 스크롤 위임
  - `textarea`에 `overflow: hidden` 적용
  - 입력 시 높이 증가 → `ScrollContainer` 자동 리사이징

6. 추가 개선 사항
- props 전달 최소화