### PR TITLE
feat: 모바일에서 대치어 적용 시 섹션 스크롤되는 기능 추가 (#180)

### DIFF
--- a/src/entities/speller/model/speller-refs-context.tsx
+++ b/src/entities/speller/model/speller-refs-context.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useWindowSize } from '@frontend-opensource/use-react-hooks'
 import { createContext, useContext, useCallback, createRef } from 'react'
 import { useSpeller } from './use-speller'
 
@@ -18,20 +17,15 @@ export const SpellerRefsProvider = ({
   children: React.ReactNode
 }) => {
   const { response, correctInfo } = useSpeller()
-  const { width } = useWindowSize()
-  const isDesktop = width && width >= 1377
 
-  const correctRefs = isDesktop
-    ? Array.from({ length: Object.keys(correctInfo).length }, () =>
-        createRef<HTMLDivElement>(),
-      )
-    : null
+  const correctRefs = Array.from(
+    { length: Object.keys(correctInfo).length },
+    () => createRef<HTMLDivElement>(),
+  )
 
-  const errorRefs = isDesktop
-    ? Array.from({ length: response?.errInfo.length }, () =>
-        createRef<HTMLDivElement>(),
-      )
-    : null
+  const errorRefs = Array.from({ length: response?.errInfo.length }, () =>
+    createRef<HTMLDivElement>(),
+  )
 
   const scrollSection = useCallback(
     (target: 'correct' | 'error', index: number) => {


### PR DESCRIPTION
## 작업 내역
- 모바일 화면에서 교정 문서, 맞춤법/문법 오류 섹션의 대치어 선택(적용) 시 양 섹션간 스크롤되는 기능을 추가했습니다.

close #180 