### PR TITLE
feat: 페이지 이동 시 섹션 스크롤 초기화하는 기능 (#162)

### DIFF
--- a/src/pages/results/ui/navigator.tsx
+++ b/src/pages/results/ui/navigator.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { CheckPayload, useSpeller } from '@/entities/speller'
+import { CheckPayload, useSpeller, useSpellerRefs } from '@/entities/speller'
 import { Spinner } from '@/shared/ui/spinner'
 import { toast } from '@/shared/lib/use-toast'
 import { spellCheckAction } from '../api/spell-check-action'
@@ -18,6 +18,8 @@ const Navigator = () => {
     handleReceiveResponse,
     updateResponseMap,
   } = useSpeller()
+  const { correctScrollContainerRef, errorScrollContainerRef } =
+    useSpellerRefs()
   const [isFetching, setIsFetching] = useState(false)
   const currentPage = Number(searchParams?.get('page')) || 1
   const currentPageRef = useRef<number | null>(null)
@@ -65,6 +67,14 @@ const Navigator = () => {
         errInfo: Object.values(correctInfo),
         pageIdx: currentPage,
       })
+
+      // 페이지 이동 시 섹션 스크롤 초기화
+      if (correctScrollContainerRef?.current) {
+        correctScrollContainerRef.current.scrollTo({ top: 0 })
+      }
+      if (errorScrollContainerRef?.current) {
+        errorScrollContainerRef.current.scrollTo({ top: 0 })
+      }
 
       handleReceiveResponse(data)
       router.push(createPageURL(page))

--- a/src/pages/results/ui/results-page.tsx
+++ b/src/pages/results/ui/results-page.tsx
@@ -8,13 +8,13 @@ import { ErrorTrackingSection } from './error-tracking-section'
 const ResultsPage = () => {
   return (
     <ContentLayout className='pb-8 tab:pb-[2.625rem] pc:pb-12'>
-      <div className='relative mb-2 mt-[0.94rem] flex min-h-[1.625rem] items-center justify-between tab:mt-[1.75rem] tab:justify-center pc:mb-[0.78rem] pc:mt-[1.97rem] pc:min-h-8'>
-        <Navigator />
-        <StrongCheckMessage />
-      </div>
-      {/* 교정 문서 & 맞춤법/문법 오류 레이아웃*/}
-      <div className='flex flex-col gap-2 overflow-auto pc:flex-row pc:gap-0'>
-        <SpellerRefsProvider>
+      <SpellerRefsProvider>
+        <div className='relative mb-2 mt-[0.94rem] flex min-h-[1.625rem] items-center justify-between tab:mt-[1.75rem] tab:justify-center pc:mb-[0.78rem] pc:mt-[1.97rem] pc:min-h-8'>
+          <Navigator />
+          <StrongCheckMessage />
+        </div>
+        {/* 교정 문서 & 맞춤법/문법 오류 레이아웃*/}
+        <div className='flex flex-col gap-2 overflow-auto pc:flex-row pc:gap-0'>
           {/* 교정 문서*/}
           <div className='flex max-h-[30.5rem] min-h-[30.5rem] w-full flex-1 flex-col rounded-lg bg-white p-5 tab:rounded-[1rem] tab:p-10 pc:max-h-[40.25rem] pc:rounded-br-none pc:rounded-tr-none'>
             <CorrectionContent />
@@ -25,8 +25,8 @@ const ResultsPage = () => {
           <div className='flex max-h-[30.5rem] min-h-[30.5rem] w-full flex-1 flex-col rounded-lg border border-blue-500 bg-white px-5 pb-3.5 pt-[1.125rem] tab:rounded-[1rem] tab:p-10 tab:pb-7 pc:max-h-[40.25rem] pc:rounded-bl-none pc:rounded-tl-none pc:border-none pc:pb-10'>
             <ErrorTrackingSection />
           </div>
-        </SpellerRefsProvider>
-      </div>
+        </div>
+      </SpellerRefsProvider>
     </ContentLayout>
   )
 }


### PR DESCRIPTION
## 작업 내역
- 페이지 이동 시 이전 페이지 섹션의 스크롤 위치가 기억되는 현상을 개선했습니다.
- 페이지가 이동할 때마다 교정 문서와 맞춤법/문법 오류 섹션의 스크롤 위치가 항상 최상단으로 이동하도록 개선했습니다.