### PR TITLE
fix: 복사하기 후 로그 전달 시 에러가 발생하는 문제 수정 (#184)

### DIFF
--- a/src/shared/lib/util.ts
+++ b/src/shared/lib/util.ts
@@ -1,20 +1,20 @@
 export const getWordsAroundIndex = (text: string, startIndex: number) => {
-  const words = text.split(/\s+/)
+  // 모든 단어 전부 매칭
+  const wordRegex = /\S+/g
+  const matches = [...text.matchAll(wordRegex)]
 
-  let currentWordStart = 0
-  let currentWordEnd = 0
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i]
+    const word = match[0]
+    const wordStart = match.index!
+    const wordEnd = wordStart + word.length
 
-  // 단어의 시작과 끝 인덱스를 계산
-  for (let i = 0; i < words.length; i++) {
-    currentWordEnd = currentWordStart + words[i].length
-    if (currentWordStart <= startIndex && startIndex < currentWordEnd) {
-      const prevWord = words[i - 1] || ''
-      const currentWord = words[i]
-      const nextWord = words[i + 1] || ''
-
-      return `${prevWord} ${currentWord} ${nextWord}`
+    // 주어진 startIndex가 단어 범위 내에 있는지 확인
+    if (wordStart <= startIndex && startIndex < wordEnd) {
+      const prevWord = matches[i - 1]?.[0] || ''
+      const nextWord = matches[i + 1]?.[0] || ''
+      return `${prevWord} ${word} ${nextWord}`
     }
-    currentWordStart = currentWordEnd + 1 // 다음 단어 시작 위치 (띄어쓰기 포함)
   }
 
   throw new Error('Invalid index')


### PR DESCRIPTION
### 기존 문제점
- 기존에는 `text.split(/\s+/)`을 사용해 공백 문자 기준으로 텍스트를 나눈 단어 배열에서 단어의 위치를 추정했으나,
공백이 여러 개이거나 줄바꿈(\r\n, \r\r)이 섞인 경우 startIndex와 실제 단어 위치가 어긋나 throw가 발생하는 문제가 있었습니다.

### 수정 내용
- `text.matchAll(/\S+/g)`을 사용하여 공백이 아닌 실제 단어들을 매칭하면서 각 단어의 시작 위치(index)를 함께 추출하도록 변경했습니다.
- matchAll로부터 가져온 시작 위치를 기반으로 현재 찾으려는 단어 범위내에 있는지 검사하도록 수정되었습니다.

https://github.com/frontend-opensource-project/speller-front/pull/179#issuecomment-2799070026 에서 공유드린 텍스트로 확인한 결과, 에러가 발생하지 않는 것을 확인하였습니다

close #184 