### PR TITLE
[#185] 텍스트 드래그 시 끊김 및 복사 동작 개선, 성능 최적화

### DIFF
--- a/src/pages/results/ui/spelling-correction-text.tsx
+++ b/src/pages/results/ui/spelling-correction-text.tsx
@@ -1,101 +1,192 @@
-import { Fragment } from 'react'
+import { ClipboardEvent, Fragment, memo, ReactNode, useMemo } from 'react'
+
 import {
   useSpeller,
   useSpellerRefs,
   CorrectMethodEnum,
+  CorrectInfo,
 } from '@/entities/speller'
 import { cn } from '@/shared/lib/tailwind-merge'
 
-const SpellingCorrectionText = () => {
+const SpellingCorrectionText = memo(() => {
   const { correctRefs, scrollSection } = useSpellerRefs()
   const { response, correctInfo, handleUpdateCorrectInfo } = useSpeller()
   const { str: text } = response
 
+  const parts = useMemo(() => {
+    return renderCorrectionSegments({
+      payload: correctInfo,
+      options: {
+        renderPreCorrectionSegment: ({ lastIndex, currentIndex, position }) => {
+          return processText(
+            text.slice(lastIndex, position.start),
+            `text-${currentIndex}`,
+          )
+        },
+        renderCorrectionTargetSegment: ({
+          currentIndex,
+          position,
+          isResolved,
+          recommendedWord,
+        }) => {
+          const key = `correction-${currentIndex}`
+
+          // 상단에 추천 단어를 표시하고 원본 텍스트에 밑줄 표시
+          return (
+            <span
+              key={key}
+              className={cn(
+                'relative inline-block pt-6 transition-all duration-300',
+                isResolved && 'pt-0',
+              )}
+              ref={correctRefs?.[currentIndex]}
+              onMouseOver={() => scrollSection('error', currentIndex)}
+              aria-label={`추천 단어 - ${recommendedWord}`}
+            >
+              <button
+                className={cn(
+                  'select-none',
+                  'absolute left-0 top-0 h-6 whitespace-nowrap text-[1rem] font-bold leading-[170%] tracking-[-0.02rem] text-slate-600 opacity-100 transition-all duration-300',
+                  isResolved && '-z-10 opacity-0',
+                )}
+                onClick={() => {
+                  handleUpdateCorrectInfo({
+                    ...position,
+                    crtStr: recommendedWord,
+                  })
+                }}
+              >
+                {/* 첫 번째 추천 교정 단어 */}
+                {recommendedWord}
+              </button>
+              <span
+                className={cn(
+                  'text-[1.125rem] font-bold leading-[160%] tracking-[-0.0225rem] underline decoration-[2px] underline-offset-[25%] tab:leading-[170%] tab:tracking-[-0.03375rem] pc:text-[1.25rem] pc:tracking-[-0.025rem]',
+                  position.correctMethod === CorrectMethodEnum.enum.띄어쓰기 &&
+                    'text-green-100',
+                  position.correctMethod === CorrectMethodEnum.enum.오탈자 &&
+                    'text-red-100',
+                  position.correctMethod === CorrectMethodEnum.enum.문맥 &&
+                    'text-purple-100',
+                  isResolved && 'text-slate-600',
+                )}
+              >
+                {processText(position.crtStr ?? position.orgStr, key)}
+              </span>
+            </span>
+          )
+        },
+        renderLastSegment: lastIndex => {
+          if (lastIndex > text.length) return null
+          const key = 'final'
+
+          return (
+            <span key={key}>{processText(text.slice(lastIndex), key)}</span>
+          )
+        },
+      },
+    })
+  }, [correctInfo, response.str])
+
+  return (
+    <div
+      className='h-0 w-full'
+      onCopy={e => handleCopyWithExclusion(e, '.select-none')}
+    >
+      <section>
+        <span className='select-text whitespace-pre-wrap break-all text-[1.125rem] leading-[160%] tracking-[-0.0225rem] [text-justify:distribute] tab:leading-[170%] tab:tracking-[-0.03375rem] pc:text-[1.25rem] pc:tracking-[-0.025rem]'>
+          {parts}
+        </span>
+      </section>
+    </div>
+  )
+})
+
+SpellingCorrectionText.displayName = 'SpellingCorrectionText'
+
+type RenderCorrectionSegmentsHandler = (data: {
+  lastIndex: number
+  currentIndex: number
+  position: CorrectInfo
+  isResolved: boolean
+  recommendedWord: string
+}) => ReactNode
+
+type RenderCorrectionSegmentsOptions = {
+  /** 각 교정 항목 앞에 위치한 일반 텍스트 렌더링 */
+  renderPreCorrectionSegment: RenderCorrectionSegmentsHandler
+  /** 교정 대상 텍스트를 추천 단어와 함께 렌더링 */
+  renderCorrectionTargetSegment: RenderCorrectionSegmentsHandler
+  /** 모든 교정 항목 이후에 남아 있는 일반 텍스트 렌더링 */
+  renderLastSegment: (lastIndex: number) => ReactNode | null
+}
+
+type RenderCorrectionSegments = (args: {
+  payload: Record<number, CorrectInfo>
+  options: RenderCorrectionSegmentsOptions
+}) => ReactNode[]
+
+const renderCorrectionSegments: RenderCorrectionSegments = ({
+  options,
+  payload,
+}) => {
   let lastIndex = 0 // useRef 대신 일반 변수 사용 - 매 렌더링마다 초기화 필요
   const parts: React.ReactNode[] = []
 
-  // 줄바꿈 문자를 포함한 텍스트를 처리하는 함수
-  const processText = (textPart: string) => {
-    return textPart.split(/\r\n|\n\r|\n|\r/).map((line, i, arr) => (
-      <Fragment key={i}>
-        {line}
-        {i < arr.length - 1 && <br />}
-      </Fragment>
-    ))
-  }
-
-  Object.values(correctInfo).forEach((pos, idx) => {
-    const isResolved = !!pos.crtStr
-    const recommendedWord = pos.candWord.split('|')[0]
-
-    // 현재 교정 위치 이전의 일반 텍스트 처리
-    if (pos.start > lastIndex) {
-      parts.push(
-        <span key={`text-${idx}`}>
-          {processText(text.slice(lastIndex, pos.start))}
-        </span>,
-      )
+  Object.values(payload).forEach((pos, idx) => {
+    const data: Parameters<RenderCorrectionSegmentsHandler>[0] = {
+      lastIndex,
+      currentIndex: idx,
+      position: pos,
+      isResolved: !!pos.crtStr,
+      recommendedWord: pos.candWord.split('|')[0],
     }
 
-    // 교정이 필요한 텍스트 처리
-    // 상단에 추천 단어를 표시하고 원본 텍스트에 밑줄 표시
-    parts.push(
-      <span
-        key={`correction-${idx}`}
-        className={cn(
-          'relative inline-block pt-6 transition-all duration-300',
-          isResolved && 'pt-0',
-        )}
-        ref={correctRefs?.[idx]}
-        onMouseOver={() => scrollSection('error', idx)}
-      >
-        <button
-          className={cn(
-            'absolute left-0 top-0 h-6 leading-none opacity-100 transition-all duration-300',
-            isResolved && '-z-10 opacity-0',
-          )}
-          onClick={() => {
-            handleUpdateCorrectInfo({
-              ...pos,
-              crtStr: recommendedWord,
-            })
-          }}
-        >
-          <span className='whitespace-nowrap text-[1rem] font-bold leading-[170%] tracking-[-0.02rem] text-slate-600'>
-            {/* 첫 번째 추천 교정 단어 */}
-            {recommendedWord}
-          </span>
-        </button>
-        <span
-          className={cn(
-            'text-[1.125rem] font-bold leading-[160%] tracking-[-0.0225rem] text-purple-100 underline decoration-[2px] underline-offset-[25%] tab:leading-[170%] tab:tracking-[-0.03375rem] pc:text-[1.25rem] pc:tracking-[-0.025rem]',
-            pos.correctMethod === CorrectMethodEnum.enum.띄어쓰기 &&
-              'text-green-100',
-            pos.correctMethod === CorrectMethodEnum.enum.오탈자 &&
-              'text-red-100',
-            pos.correctMethod === CorrectMethodEnum.enum.문맥 &&
-              'text-purple-100',
-            isResolved && 'text-slate-600',
-          )}
-        >
-          {processText(pos.crtStr ?? pos.orgStr)}
-        </span>
-      </span>,
-    )
+    // 각 교정 항목 앞에 위치한 일반 텍스트 렌더링
+    if (pos.start > lastIndex) {
+      parts.push(options.renderPreCorrectionSegment(data))
+    }
 
+    // 교정 대상 텍스트를 추천 단어와 함께 렌더링
+    parts.push(options.renderCorrectionTargetSegment(data))
     lastIndex = pos.end
   })
 
-  // 마지막 교정 위치 이후의 남은 텍스트 처리
-  if (lastIndex < text.length) {
-    parts.push(<span key='final'>{processText(text.slice(lastIndex))}</span>)
-  }
+  // 모든 교정 항목 이후에 남아 있는 일반 텍스트 렌더링
+  parts.push(options.renderLastSegment(lastIndex))
 
-  return (
-    <div className='h-0 w-full whitespace-pre-wrap break-all text-[1.125rem] leading-[160%] tracking-[-0.0225rem] [text-justify:distribute] tab:leading-[170%] tab:tracking-[-0.03375rem] pc:text-[1.25rem] pc:tracking-[-0.025rem]'>
-      {parts}
-    </div>
-  )
+  return parts
+}
+
+// 줄바꿈 문자를 포함한 텍스트를 처리하는 함수
+const processText = (textPart: string, key?: string) => {
+  return textPart.split(/\r\n|\n\r|\n|\r/).map((line, idx, arr) => (
+    <Fragment key={`${key}-${idx}`}>
+      {line}
+      {idx < arr.length - 1 ? <br /> : null}
+    </Fragment>
+  ))
+}
+
+// 클립보드 복사 시 특정 셀렉터가 적용된 요소의 텍스트를 제외하는 핸들러
+const handleCopyWithExclusion = (e: ClipboardEvent, selectors: string) => {
+  const selection = window.getSelection()
+
+  if (selection) {
+    const range = selection.getRangeAt(0)
+    const clonedContent = range.cloneContents()
+
+    clonedContent.querySelectorAll(selectors).forEach(el => {
+      if (el.parentNode) {
+        el.parentNode.removeChild(el)
+      }
+    })
+
+    if (clonedContent.textContent) {
+      e.clipboardData.setData('text/plain', clonedContent.textContent)
+      e.preventDefault()
+    }
+  }
 }
 
 export { SpellingCorrectionText }


### PR DESCRIPTION
작업내용
- 모바일(AOS, iOS) 환경에서 교정 단위 위에서 드래그 시 끊김이 발생하는 문제를 수정했습니다.
- PC 및 모바일에서 교정된 단어와 원문 단어를 동시에 드래그할 경우, 원문 전체 문장만 정확히 복사되도록 처리했습니다.
- 드래그 후 붙여넣기 시 교정된 단어는 제외되고, 원문 문장만 붙여넣어지도록 개선했습니다.
- 교정 문서 컴포넌트의 불필요한 리렌더링을 일부 최적화했습니다.
- `SpellingCorrectionText` 컴포넌트의 가독성을 높이기 위해 비즈니스 로직을 함수로 분리하고, 각 책임을 명확히 했습니다.

작업물

문제 버전 (AOS, iOS 동일)

https://github.com/user-attachments/assets/4622f87d-1382-4f10-a117-b5b24754a3b6


개선 버전 (AOS, iOS 동일)

https://github.com/user-attachments/assets/e7f5a615-f375-473a-9e9e-4773b717e049

성능 최적화

| 항목                                   | 최적화 전         | 최적화 후         | 개선 효과                  |
|----------------------------------------|-------------------|-------------------|----------------------------|
| 렌더링 duration (CorrectionText)       | 최대 10.1ms       | 최대 2.5ms        | 약 75% 감소                |
| 불필요한 주기당 평균 시간               | 약 6.4ms          | 약 1.5ms          | 70~80% 감소                |

---







