### PR TITLE
design: 맞춤법/문법 오류 타이틀 스타일 수정 (#188)

### DIFF
--- a/src/pages/results/ui/error-tracking-section.tsx
+++ b/src/pages/results/ui/error-tracking-section.tsx
@@ -29,7 +29,7 @@ const ErrorTrackingSection = () => {
   return (
     <>
       <div className='mb-[1rem] flex justify-between tab:mb-[1.25rem]'>
-        <h2 className='text-lg font-semibold leading-[1.9125rem] tracking-[-0.0225rem] tab:text-[1.375rem] tab:leading-[2.3375rem] tab:tracking-[-0.0275rem] pc:text-[1.5rem] pc:leading-[2.55rem] pc:tracking-[-0.03rem]'>
+        <h2 className='flex gap-2 text-lg font-semibold leading-[1.9125rem] tracking-[-0.0225rem] tab:text-[1.375rem] tab:leading-[2.3375rem] tab:tracking-[-0.0275rem] pc:text-[1.5rem] pc:leading-[2.55rem] pc:tracking-[-0.03rem]'>
           맞춤법/문법 오류
           <span className='text-red-100'>{errInfo.length}개</span>
         </h2>


### PR DESCRIPTION
## 작업 내역
- 맞춤법/문법 오류 타이틀과 오류 갯수의 간격을 수정했습니다.

## 스크린샷
### as-is
![스크린샷 2025-04-29 00 34 29](https://github.com/user-attachments/assets/119477d7-ec8d-4c47-9938-b318ff9ae1f0)

### to-be
![스크린샷 2025-04-29 00 35 10](https://github.com/user-attachments/assets/f8399590-e989-4ddd-9158-33adaaf4c5f1)
