### PR TITLE
fix: 맞춤법/문법 오류 섹션에서 '입력 내용'이 길어질 때 UI가 틀어지는 이슈 (#189)

### DIFF
--- a/src/pages/results/ui/error-info-section.tsx
+++ b/src/pages/results/ui/error-info-section.tsx
@@ -51,17 +51,19 @@ const ErrorInfoSection = <T extends HTMLDivElement>({
     <div className={cn('my-[1.125rem]', errorIdx === 0 && 'mt-0')} {...props}>
       <dl className='grid grid-cols-[3.5rem_1fr] gap-3 tab:grid-cols-[4.75rem_1fr] pc:grid-cols-[4.5rem_1fr] pc:gap-1'>
         <dt className='py-0.5 text-sm font-semibold tab:text-lg'>입력 내용</dt>
-        <dd className='flex items-center justify-between'>
+        <dd className='flex items-start justify-between gap-2'>
           <Button
             variant='ghost'
-            className='flex h-auto items-center gap-2 p-0 text-base font-semibold hover:bg-transparent tab:gap-3.5 tab:text-xl'
+            className='flex h-auto items-start gap-2 p-0 text-base font-semibold hover:bg-transparent tab:gap-3.5 tab:text-xl'
             onClick={handleRevert}
           >
             <BulletBadge
               method={correctMethod}
-              className='mx-1.5 size-3 tab:mx-2.5'
+              className='mx-1.5 my-[0.3125rem] size-3 shrink-0 tab:mx-2.5 tab:my-2'
             />
-            {orgStr}
+            <span className='block whitespace-pre-line break-all text-left'>
+              {orgStr}
+            </span>
           </Button>
           <ReportForm>
             <Button
@@ -70,7 +72,7 @@ const ErrorInfoSection = <T extends HTMLDivElement>({
               onClick={() => updateErrInfoIndex(errorIdx)}
             >
               <SendIcon className='!size-6 tab:!size-8' />
-              <span className='sr-only font-normal tab:not-sr-only tab:text-lg'>
+              <span className='sr-only font-normal tab:not-sr-only tab:whitespace-nowrap tab:text-lg'>
                 오류 제보
               </span>
             </Button>

--- a/src/pages/results/ui/results-page.tsx
+++ b/src/pages/results/ui/results-page.tsx
@@ -16,13 +16,13 @@ const ResultsPage = () => {
         {/* 교정 문서 & 맞춤법/문법 오류 레이아웃*/}
         <div className='flex flex-col gap-2 overflow-auto pc:flex-row pc:gap-0'>
           {/* 교정 문서*/}
-          <div className='flex max-h-[30.5rem] min-h-[30.5rem] w-full flex-1 flex-col rounded-lg bg-white p-5 tab:rounded-[1rem] tab:p-10 pc:max-h-[40.25rem] pc:rounded-br-none pc:rounded-tr-none'>
+          <div className='flex max-h-[30.5rem] min-h-[30.5rem] w-full flex-1 flex-col rounded-lg bg-white p-5 tab:rounded-[1rem] tab:p-10 pc:max-h-[40.25rem] pc:w-1/2 pc:flex-none pc:rounded-br-none pc:rounded-tr-none'>
             <CorrectionContent />
             {/* 글자수 & 돌아가기, 복사하기 버튼 */}
             <ResultsControl />
           </div>
           {/* 맞춤법/문법 오류 */}
-          <div className='flex max-h-[30.5rem] min-h-[30.5rem] w-full flex-1 flex-col rounded-lg border border-blue-500 bg-white px-5 pb-3.5 pt-[1.125rem] tab:rounded-[1rem] tab:p-10 tab:pb-7 pc:max-h-[40.25rem] pc:rounded-bl-none pc:rounded-tl-none pc:border-none pc:pb-10'>
+          <div className='flex max-h-[30.5rem] min-h-[30.5rem] w-full flex-1 flex-col rounded-lg border border-blue-500 bg-white px-5 pb-3.5 pt-[1.125rem] tab:rounded-[1rem] tab:p-10 tab:pb-7 pc:max-h-[40.25rem] pc:w-1/2 pc:flex-none pc:rounded-bl-none pc:rounded-tl-none pc:border-none pc:pb-10'>
             <ErrorTrackingSection />
           </div>
         </div>


### PR DESCRIPTION
## 작업 내역
- 맞춤법/문법 오류 섹션에서 '입력 내용'이 길어질 때 UI가 틀어지는 이슈를 해결했습니다.

## 스크린샷
### as-is
![image](https://github.com/user-attachments/assets/914640a8-69a4-40fe-b229-bee61758e269)

### to-be
![스크린샷 2025-05-03 00 12 14](https://github.com/user-attachments/assets/ea2058ad-67b0-4ea9-8df2-74b20cc9f90b)
![스크린샷 2025-05-03 00 12 23](https://github.com/user-attachments/assets/c93eab3e-e826-4587-a0e2-ab808cd0480e)
![스크린샷 2025-05-03 00 12 33](https://github.com/user-attachments/assets/599c1827-b1a0-4176-ac94-d5ab4d6de1f9)
