### PR TITLE
design: 오류 구분 색상 변경 (#190)

### DIFF
--- a/src/entities/speller/index.ts
+++ b/src/entities/speller/index.ts
@@ -1,4 +1,5 @@
 export { SpellerApi } from './api/speller-service'
+export { applyMethodColor } from './lib/apply-method-color'
 export { parseCandidateWords } from './lib/parse-candidate-words'
 export type {
   UserReplacePayload,
@@ -15,10 +16,10 @@ export {
   type CheckResponse,
   type ClickReplacePayload,
 } from './model/speller-schema'
-export { useSpeller } from './model/use-speller'
 export {
   SpellerRefsProvider,
   useSpellerRefs,
 } from './model/speller-refs-context'
+export { useSpeller } from './model/use-speller'
 export { spellerReducer, type SpellerState } from './model/speller-slice'
 export { SpellerSetting } from './ui/speller-setting'

--- a/src/entities/speller/index.ts
+++ b/src/entities/speller/index.ts
@@ -1,8 +1,5 @@
 export { SpellerApi } from './api/speller-service'
-export {
-  applyTextMethodColor,
-  applyBgMethodColor,
-} from './lib/apply-method-color'
+export { getTextMethodColor, getBgMethodColor } from './lib/get-method-color'
 export { parseCandidateWords } from './lib/parse-candidate-words'
 export type {
   UserReplacePayload,

--- a/src/entities/speller/index.ts
+++ b/src/entities/speller/index.ts
@@ -1,5 +1,8 @@
 export { SpellerApi } from './api/speller-service'
-export { applyMethodColor } from './lib/apply-method-color'
+export {
+  applyTextMethodColor,
+  applyBgMethodColor,
+} from './lib/apply-method-color'
 export { parseCandidateWords } from './lib/parse-candidate-words'
 export type {
   UserReplacePayload,

--- a/src/entities/speller/lib/apply-method-color.ts
+++ b/src/entities/speller/lib/apply-method-color.ts
@@ -1,14 +1,27 @@
 import { type CorrectMethod, CorrectMethodEnum } from '../model/speller-schema'
 
-export const applyMethodColor = (method: CorrectMethod) => {
+export const applyTextMethodColor = (method: CorrectMethod) => {
   switch (method) {
     case CorrectMethodEnum.enum.띄어쓰기:
-      return 'purple-100'
+      return 'text-purple-100'
     case CorrectMethodEnum.enum.오탈자:
-      return 'red-100'
+      return 'text-red-100'
     case CorrectMethodEnum.enum.문맥:
-      return 'green-100'
+      return 'text-green-100'
     default:
-      return 'green-100'
+      return 'text-green-100'
+  }
+}
+
+export const applyBgMethodColor = (method: CorrectMethod) => {
+  switch (method) {
+    case CorrectMethodEnum.enum.띄어쓰기:
+      return 'bg-purple-100'
+    case CorrectMethodEnum.enum.오탈자:
+      return 'bg-red-100'
+    case CorrectMethodEnum.enum.문맥:
+      return 'bg-green-100'
+    default:
+      return 'bg-green-100'
   }
 }

--- a/src/entities/speller/lib/apply-method-color.ts
+++ b/src/entities/speller/lib/apply-method-color.ts
@@ -1,0 +1,14 @@
+import { type CorrectMethod, CorrectMethodEnum } from '../model/speller-schema'
+
+export const applyMethodColor = (method: CorrectMethod) => {
+  switch (method) {
+    case CorrectMethodEnum.enum.띄어쓰기:
+      return 'purple-100'
+    case CorrectMethodEnum.enum.오탈자:
+      return 'red-100'
+    case CorrectMethodEnum.enum.문맥:
+      return 'green-100'
+    default:
+      return 'green-100'
+  }
+}

--- a/src/entities/speller/lib/get-method-color.ts
+++ b/src/entities/speller/lib/get-method-color.ts
@@ -1,6 +1,6 @@
 import { type CorrectMethod, CorrectMethodEnum } from '../model/speller-schema'
 
-export const applyTextMethodColor = (method: CorrectMethod) => {
+export const getTextMethodColor = (method: CorrectMethod) => {
   switch (method) {
     case CorrectMethodEnum.enum.띄어쓰기:
       return 'text-purple-100'
@@ -13,7 +13,7 @@ export const applyTextMethodColor = (method: CorrectMethod) => {
   }
 }
 
-export const applyBgMethodColor = (method: CorrectMethod) => {
+export const getBgMethodColor = (method: CorrectMethod) => {
   switch (method) {
     case CorrectMethodEnum.enum.띄어쓰기:
       return 'bg-purple-100'

--- a/src/entities/speller/model/speller-schema.ts
+++ b/src/entities/speller/model/speller-schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-enum CorrectMethod {
+export enum CorrectMethod {
   띄어쓰기 = 1,
   오탈자 = 2,
   문맥 = 3,

--- a/src/pages/results/ui/bullet-badge.tsx
+++ b/src/pages/results/ui/bullet-badge.tsx
@@ -11,11 +11,11 @@ const BulletBadge = ({ className, method }: BulletBadgeProps) => {
   return (
     <i
       className={cn(
-        'size-2 rounded-full bg-purple-100',
+        'size-2 rounded-full bg-green-100',
         className,
-        method === CorrectMethodEnum.enum.띄어쓰기 && 'bg-green-100',
+        method === CorrectMethodEnum.enum.띄어쓰기 && 'bg-purple-100',
         method === CorrectMethodEnum.enum.오탈자 && 'bg-red-100',
-        method === CorrectMethodEnum.enum.문맥 && 'bg-purple-100',
+        method === CorrectMethodEnum.enum.문맥 && 'bg-green-100',
       )}
     />
   )

--- a/src/pages/results/ui/bullet-badge.tsx
+++ b/src/pages/results/ui/bullet-badge.tsx
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { applyMethodColor, CorrectMethodEnum } from '@/entities/speller'
+import { applyBgMethodColor, CorrectMethodEnum } from '@/entities/speller'
 import { cn } from '@/shared/lib/tailwind-merge'
 
 interface BulletBadgeProps {
@@ -12,7 +12,7 @@ const BulletBadge = ({ className, method }: BulletBadgeProps) => {
     <i
       className={cn(
         'size-2 rounded-full',
-        `bg-${applyMethodColor(method)}`,
+        `${applyBgMethodColor(method)}`,
         className,
       )}
     />

--- a/src/pages/results/ui/bullet-badge.tsx
+++ b/src/pages/results/ui/bullet-badge.tsx
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { CorrectMethodEnum } from '@/entities/speller'
+import { applyMethodColor, CorrectMethodEnum } from '@/entities/speller'
 import { cn } from '@/shared/lib/tailwind-merge'
 
 interface BulletBadgeProps {
@@ -11,11 +11,9 @@ const BulletBadge = ({ className, method }: BulletBadgeProps) => {
   return (
     <i
       className={cn(
-        'size-2 rounded-full bg-green-100',
+        'size-2 rounded-full',
+        `bg-${applyMethodColor(method)}`,
         className,
-        method === CorrectMethodEnum.enum.띄어쓰기 && 'bg-purple-100',
-        method === CorrectMethodEnum.enum.오탈자 && 'bg-red-100',
-        method === CorrectMethodEnum.enum.문맥 && 'bg-green-100',
       )}
     />
   )

--- a/src/pages/results/ui/bullet-badge.tsx
+++ b/src/pages/results/ui/bullet-badge.tsx
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { applyBgMethodColor, CorrectMethodEnum } from '@/entities/speller'
+import { getBgMethodColor, CorrectMethodEnum } from '@/entities/speller'
 import { cn } from '@/shared/lib/tailwind-merge'
 
 interface BulletBadgeProps {
@@ -12,7 +12,7 @@ const BulletBadge = ({ className, method }: BulletBadgeProps) => {
     <i
       className={cn(
         'size-2 rounded-full',
-        `${applyBgMethodColor(method)}`,
+        `${getBgMethodColor(method)}`,
         className,
       )}
     />

--- a/src/pages/results/ui/custom-text-editor-content.tsx
+++ b/src/pages/results/ui/custom-text-editor-content.tsx
@@ -1,4 +1,4 @@
-import { CorrectMethodEnum } from '@/entities/speller'
+import { applyMethodColor } from '@/entities/speller'
 import { cn } from '@/shared/lib/tailwind-merge'
 import { Button } from '@/shared/ui/button'
 import { Input } from '@/shared/ui/input'
@@ -23,10 +23,7 @@ export const CustomTextEditorContent = ({
         <p
           className={cn(
             'flex items-center justify-center text-[0.95rem] tab:text-lg pc:text-base pc:leading-normal',
-            correctMethod === CorrectMethodEnum.enum.띄어쓰기 &&
-              'text-purple-100',
-            correctMethod === CorrectMethodEnum.enum.오탈자 && 'text-red-100',
-            correctMethod === CorrectMethodEnum.enum.문맥 && 'text-green-100',
+            `text-${applyMethodColor(correctMethod)}`,
           )}
         >
           <BulletBadge

--- a/src/pages/results/ui/custom-text-editor-content.tsx
+++ b/src/pages/results/ui/custom-text-editor-content.tsx
@@ -1,4 +1,4 @@
-import { applyTextMethodColor } from '@/entities/speller'
+import { getTextMethodColor } from '@/entities/speller'
 import { cn } from '@/shared/lib/tailwind-merge'
 import { Button } from '@/shared/ui/button'
 import { Input } from '@/shared/ui/input'
@@ -23,7 +23,7 @@ export const CustomTextEditorContent = ({
         <p
           className={cn(
             'flex items-center justify-center text-[0.95rem] tab:text-lg pc:text-base pc:leading-normal',
-            `${applyTextMethodColor(correctMethod)}`,
+            `${getTextMethodColor(correctMethod)}`,
           )}
         >
           <BulletBadge

--- a/src/pages/results/ui/custom-text-editor-content.tsx
+++ b/src/pages/results/ui/custom-text-editor-content.tsx
@@ -24,9 +24,9 @@ export const CustomTextEditorContent = ({
           className={cn(
             'flex items-center justify-center text-[0.95rem] tab:text-lg pc:text-base pc:leading-normal',
             correctMethod === CorrectMethodEnum.enum.띄어쓰기 &&
-              'text-green-100',
+              'text-purple-100',
             correctMethod === CorrectMethodEnum.enum.오탈자 && 'text-red-100',
-            correctMethod === CorrectMethodEnum.enum.문맥 && 'text-purple-100',
+            correctMethod === CorrectMethodEnum.enum.문맥 && 'text-green-100',
           )}
         >
           <BulletBadge

--- a/src/pages/results/ui/custom-text-editor-content.tsx
+++ b/src/pages/results/ui/custom-text-editor-content.tsx
@@ -1,4 +1,4 @@
-import { applyMethodColor } from '@/entities/speller'
+import { applyTextMethodColor } from '@/entities/speller'
 import { cn } from '@/shared/lib/tailwind-merge'
 import { Button } from '@/shared/ui/button'
 import { Input } from '@/shared/ui/input'
@@ -23,7 +23,7 @@ export const CustomTextEditorContent = ({
         <p
           className={cn(
             'flex items-center justify-center text-[0.95rem] tab:text-lg pc:text-base pc:leading-normal',
-            `text-${applyMethodColor(correctMethod)}`,
+            `${applyTextMethodColor(correctMethod)}`,
           )}
         >
           <BulletBadge

--- a/src/pages/results/ui/spelling-correction-text.tsx
+++ b/src/pages/results/ui/spelling-correction-text.tsx
@@ -3,7 +3,7 @@ import { ClipboardEvent, Fragment, memo, ReactNode, useMemo } from 'react'
 import {
   useSpeller,
   useSpellerRefs,
-  applyTextMethodColor,
+  getTextMethodColor,
   CorrectInfo,
 } from '@/entities/speller'
 import { cn } from '@/shared/lib/tailwind-merge'
@@ -62,7 +62,7 @@ const SpellingCorrectionText = memo(() => {
               <span
                 className={cn(
                   'text-[1.125rem] font-bold leading-[160%] tracking-[-0.0225rem] underline decoration-[2px] underline-offset-[25%] tab:leading-[170%] tab:tracking-[-0.03375rem] pc:text-[1.25rem] pc:tracking-[-0.025rem]',
-                  `${applyTextMethodColor(position.correctMethod)}`,
+                  `${getTextMethodColor(position.correctMethod)}`,
                   isResolved && 'text-slate-600',
                 )}
               >

--- a/src/pages/results/ui/spelling-correction-text.tsx
+++ b/src/pages/results/ui/spelling-correction-text.tsx
@@ -70,11 +70,11 @@ const SpellingCorrectionText = () => {
           className={cn(
             'text-[1.125rem] font-bold leading-[160%] tracking-[-0.0225rem] text-purple-100 underline decoration-[2px] underline-offset-[25%] tab:leading-[170%] tab:tracking-[-0.03375rem] pc:text-[1.25rem] pc:tracking-[-0.025rem]',
             pos.correctMethod === CorrectMethodEnum.enum.띄어쓰기 &&
-              'text-green-100',
+              'text-purple-100',
             pos.correctMethod === CorrectMethodEnum.enum.오탈자 &&
               'text-red-100',
             pos.correctMethod === CorrectMethodEnum.enum.문맥 &&
-              'text-purple-100',
+              'text-green-100',
             isResolved && 'text-slate-600',
           )}
         >

--- a/src/pages/results/ui/spelling-correction-text.tsx
+++ b/src/pages/results/ui/spelling-correction-text.tsx
@@ -2,7 +2,7 @@ import { Fragment } from 'react'
 import {
   useSpeller,
   useSpellerRefs,
-  CorrectMethodEnum,
+  applyMethodColor,
 } from '@/entities/speller'
 import { cn } from '@/shared/lib/tailwind-merge'
 
@@ -68,13 +68,8 @@ const SpellingCorrectionText = () => {
         </button>
         <span
           className={cn(
-            'text-[1.125rem] font-bold leading-[160%] tracking-[-0.0225rem] text-purple-100 underline decoration-[2px] underline-offset-[25%] tab:leading-[170%] tab:tracking-[-0.03375rem] pc:text-[1.25rem] pc:tracking-[-0.025rem]',
-            pos.correctMethod === CorrectMethodEnum.enum.띄어쓰기 &&
-              'text-purple-100',
-            pos.correctMethod === CorrectMethodEnum.enum.오탈자 &&
-              'text-red-100',
-            pos.correctMethod === CorrectMethodEnum.enum.문맥 &&
-              'text-green-100',
+            'text-[1.125rem] font-bold leading-[160%] tracking-[-0.0225rem] underline decoration-[2px] underline-offset-[25%] tab:leading-[170%] tab:tracking-[-0.03375rem] pc:text-[1.25rem] pc:tracking-[-0.025rem]',
+            `text-${applyMethodColor(pos.correctMethod)}`,
             isResolved && 'text-slate-600',
           )}
         >

--- a/src/pages/results/ui/spelling-correction-text.tsx
+++ b/src/pages/results/ui/spelling-correction-text.tsx
@@ -3,7 +3,7 @@ import { ClipboardEvent, Fragment, memo, ReactNode, useMemo } from 'react'
 import {
   useSpeller,
   useSpellerRefs,
-  applyMethodColor,
+  applyTextMethodColor,
   CorrectInfo,
 } from '@/entities/speller'
 import { cn } from '@/shared/lib/tailwind-merge'
@@ -62,7 +62,7 @@ const SpellingCorrectionText = memo(() => {
               <span
                 className={cn(
                   'text-[1.125rem] font-bold leading-[160%] tracking-[-0.0225rem] underline decoration-[2px] underline-offset-[25%] tab:leading-[170%] tab:tracking-[-0.03375rem] pc:text-[1.25rem] pc:tracking-[-0.025rem]',
-                  `text-${applyMethodColor(position.correctMethod)}`,
+                  `${applyTextMethodColor(position.correctMethod)}`,
                   isResolved && 'text-slate-600',
                 )}
               >


### PR DESCRIPTION
## 작업 내역
- 오류 구분 색상을 요구 사항에 맞게 변경했습니다.
- 하드코딩으로 적용했던 색상을 `applyMethodColor()` 함수로 적용하도록 변경해 관리 포인트를 줄였습니다.

## 스크린샷
### as-is
![스크린샷 2025-05-03 00 54 31](https://github.com/user-attachments/assets/adf4ce0f-9799-486d-ba3d-8b9192c91c27)

### to-be
![스크린샷 2025-05-03 00 53 49](https://github.com/user-attachments/assets/48d5bfb6-4bfb-428f-9bc5-5a39ea88e159)
