### PR TITLE
[#202] speller-refs-context 초기 렌더링 시 스크롤 동작 안됨 오류 수정 제안

### DIFF
--- a/src/entities/speller/model/speller-refs-context.tsx
+++ b/src/entities/speller/model/speller-refs-context.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import { createContext, useContext, createRef, useRef } from 'react'
-import { useSpeller } from './use-speller'
+import { createContext, useContext, useRef } from 'react'
 import { ScrollContainerHandle } from '@/shared/ui/scroll-container'
 
 interface SpellerRefsContextType {
-  correctRefs: React.RefObject<HTMLDivElement>[] | null
-  errorRefs: React.RefObject<HTMLDivElement>[] | null
+  correctRefs: React.MutableRefObject<(HTMLElement | null)[]> | null
+  errorRefs: React.MutableRefObject<(HTMLElement | null)[]> | null
   correctScrollContainerRef: React.RefObject<ScrollContainerHandle> | null
   errorScrollContainerRef: React.RefObject<ScrollContainerHandle> | null
   scrollSection: (target: 'correct' | 'error', index: number) => void
@@ -21,16 +20,9 @@ export const SpellerRefsProvider = ({
 }) => {
   const correctScrollContainerRef = useRef<ScrollContainerHandle>(null)
   const errorScrollContainerRef = useRef<ScrollContainerHandle>(null)
-  const { response, correctInfo } = useSpeller()
 
-  const correctRefs = Array.from(
-    { length: Object.keys(correctInfo).length },
-    () => createRef<HTMLDivElement>(),
-  )
-
-  const errorRefs = Array.from({ length: response?.errInfo.length }, () =>
-    createRef<HTMLDivElement>(),
-  )
+  const correctRefs = useRef<(HTMLElement | null)[]>([])
+  const errorRefs = useRef<(HTMLElement | null)[]>([])
 
   const scrollSection = (target: 'correct' | 'error', index: number) => {
     const refs = target === 'correct' ? correctRefs : errorRefs
@@ -39,7 +31,7 @@ export const SpellerRefsProvider = ({
 
     if (!refs || !scrollContainerRef.current) return
 
-    const targetElement = refs[index]?.current
+    const targetElement = refs.current[index]
 
     if (targetElement && scrollContainerRef.current) {
       scrollContainerRef.current.scrollToElement(targetElement)

--- a/src/pages/results/ui/error-tracking-section.tsx
+++ b/src/pages/results/ui/error-tracking-section.tsx
@@ -38,7 +38,10 @@ const ErrorTrackingSection = () => {
               <hr className={cn('border-slate-200', idx === 0 && 'hidden')} />
               <ErrorInfoSection
                 errorInfo={info}
-                ref={errorRefs?.[idx]}
+                ref={el => {
+                  if (!errorRefs) return
+                  errorRefs.current[idx] = el
+                }}
                 onMouseOver={() => scrollSection('correct', idx)}
               />
             </Fragment>

--- a/src/pages/results/ui/error-tracking-section.tsx
+++ b/src/pages/results/ui/error-tracking-section.tsx
@@ -39,7 +39,7 @@ const ErrorTrackingSection = () => {
               <ErrorInfoSection
                 errorInfo={info}
                 ref={el => {
-                  if (!errorRefs) return
+                  if (!errorRefs || !el) return
                   errorRefs.current[idx] = el
                 }}
                 onMouseOver={() => scrollSection('correct', idx)}

--- a/src/pages/results/ui/spelling-correction-text.tsx
+++ b/src/pages/results/ui/spelling-correction-text.tsx
@@ -40,7 +40,7 @@ const SpellingCorrectionText = memo(() => {
                 isResolved && 'pt-0',
               )}
               ref={el => {
-                if (!correctRefs) return
+                if (!correctRefs || !el) return
                 correctRefs.current[currentIndex] = el
               }}
               onMouseOver={() => scrollSection('error', currentIndex)}

--- a/src/pages/results/ui/spelling-correction-text.tsx
+++ b/src/pages/results/ui/spelling-correction-text.tsx
@@ -39,7 +39,10 @@ const SpellingCorrectionText = memo(() => {
                 'relative inline-block pt-6 transition-all duration-300',
                 isResolved && 'pt-0',
               )}
-              ref={correctRefs?.[currentIndex]}
+              ref={el => {
+                if (!correctRefs) return
+                correctRefs.current[currentIndex] = el
+              }}
               onMouseOver={() => scrollSection('error', currentIndex)}
               aria-label={`추천 단어 - ${recommendedWord}`}
             >


### PR DESCRIPTION
맞춤법 결과 페이지 렌더링후, 마우스오버 이벤트가 발생해도 스크롤이 발생하지 않는 이슈가 발생했습니다.

기존에는 리스트 렌더링 시 createRef() 방식으로 ref 배열을 초기화하고, 각 요소에 다음과 같이 연결했습니다:
```ts
const correctRefs = Array.from(
  { length: correctInfo.length },
  () => createRef<HTMLDivElement>()
)

<div ref={correctRefs[index]} />
```
해당 방식의 로깅 확인결과 첫 초기 렌더링 시 ref.current가 null인 상태이며,
ref가 연결되기 전 스크롤을 시도하면 실패하는 문제가 있었습니다.
```
[{…}, {…}, {…}, {…}, {…}, {…}, {…}]
0: {current: null}
1: {current: null}
2: {current: null}
3: {current: null}
4: {current: null}
5: {current: null}
6: {current: null}
length: 7
```
---

useRef([])와 콜백 ref를 사용하여 ref 배열을 직접 관리하도록 구조를 변경했습니다:

```ts
const correctRefs = useRef<(HTMLDivElement | null)[]>([])

<div
  ref={el => {
    correctRefs.current[index] = el
  }}
/>
```
콜백 ref 방식은 DOM이 mount된 직후에만 ref.current가 할당되므로,
첫 렌더링 시점에도 scrollToElement()가 정확히 동작하도록 보장합니다.