### PR TITLE
fix: 광고 영역의 배경색 제거 (#204)

### DIFF
--- a/src/shared/ui/base-layout.tsx
+++ b/src/shared/ui/base-layout.tsx
@@ -11,7 +11,7 @@ const BaseLayout: FC<PropsWithChildren> = ({ children }) => {
         {/* 레이아웃 쉬프트 방지 */}
         <div className='flex h-full flex-1'>{children}</div>
         {/* 광고 영역 */}
-        <div className='my-24 hidden rounded-md bg-slate-300 pc:ml-5 pc:block'>
+        <div className='my-24 hidden rounded-md pc:ml-5 pc:block'>
           <GoogleAdSense
             className='h-[37.5rem] w-40 place-content-center'
             data-ad-slot='9725653724'

--- a/src/shared/ui/footer.tsx
+++ b/src/shared/ui/footer.tsx
@@ -72,7 +72,7 @@ const Footer = () => {
           <div className='hidden h-[90px] w-[728px] pc:block'>
             {/* 광고 영역 */}
             <GoogleAdSense
-              className='mb-1 hidden h-[50px] w-80 rounded-sm bg-slate-300 p-4 text-center tab:mb-0 tab:h-[90px] tab:w-[728px] pc:block'
+              className='mb-1 hidden h-[50px] w-80 rounded-sm p-4 text-center tab:mb-0 tab:h-[90px] tab:w-[728px] pc:block'
               data-ad-slot='4790060150'
               data-full-width-responsive='true'
             />


### PR DESCRIPTION
배포된 사이트에서 광고가 표시될 때 회색 배경이 표시되는 문제가 있습니다.

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/af853a7e-530c-418e-8dcf-e9a95b60d1e5" />

배경색을 제거하였습니다.
<img width="1225" alt="image" src="https://github.com/user-attachments/assets/c407fc7f-cd26-4fe3-86d8-f2c2f5e59329" />

close #204 