### PR TITLE
fix: 화면 크기 변경 시 광고가 다시 로드되도록 수정 및 모바일에서 광고 표시 (#208)

### DIFF
--- a/src/shared/lib/get-break-point.ts
+++ b/src/shared/lib/get-break-point.ts
@@ -1,0 +1,13 @@
+type Breakpoint = 'ssr' | 'mobile' | 'tablet' | 'desktop'
+
+const getBreakpoint = (): Breakpoint => {
+  if (typeof window === 'undefined') return 'ssr'
+  const width = window.innerWidth
+
+  if (width < 726) return 'mobile'
+  if (width < 1377) return 'tablet'
+
+  return 'desktop'
+}
+
+export { getBreakpoint }

--- a/src/shared/lib/google-ad-sense-production.tsx
+++ b/src/shared/lib/google-ad-sense-production.tsx
@@ -1,0 +1,78 @@
+// NOTE: 현재 프로덕션에 적용된 파일입니다. 참고용이며, 이 파일에서는 모바일에서 광고가 표시되지 않는 문제가 있습니다.
+// google-ad-sense.tsx에서 로직 수정 후 광고가 정상적으로 표시된다면 해당 파일은 삭제할 예정입니다.
+
+'use client'
+
+import { cn } from '@/shared/lib/tailwind-merge'
+import React, { useEffect, useRef, useState } from 'react'
+import { useDesktop } from './use-desktop'
+
+declare global {
+  interface Window {
+    adsbygoogle: { [key: string]: unknown }[]
+  }
+}
+
+interface GoogleAdSenseProps {
+  className?: string
+}
+
+const NO_DELAY = 0 // 화면 크기 전환 시 지연 없이 렌더링하여, 데스크탑 전환 시 발생할 수 있는 느린 레이아웃 쉬프트 방지
+
+const GoogleAdSense = ({ className, ...props }: GoogleAdSenseProps) => {
+  const adRef = useRef<HTMLModElement>(null)
+  const [isMounted, setIsMounted] = useState(false)
+  // 데스크탑: 수동 광고 사용
+  // 태블릿/모바일: 자동 광고 사용 (Google이 <ins> 태그 없이 광고 자동 삽입)
+  const isDesktop = useDesktop(NO_DELAY)
+
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  useEffect(() => {
+    // isMounted가 true가 된 후 (클라이언트에서 마운트 완료)
+    // isDesktop이 true이고 (데스크탑 화면)
+    // adRef.current가 존재할 때 (ins 태그가 렌더링 됨)
+    if (isMounted && isDesktop && adRef.current) {
+      // CSS가 적용되고 DOM이 안정화될 시간을 주기 위해 짧은 지연 추가
+      const timerId = setTimeout(() => {
+        try {
+          ;(window.adsbygoogle = window.adsbygoogle || []).push({})
+        } catch (e) {
+          console.error('Error pushing ad to AdSense:', e)
+        }
+      }, 100) // 100ms 지연, 필요에 따라 조절 가능
+
+      return () => clearTimeout(timerId) // 클린업 함수
+    }
+  }, [isMounted, isDesktop]) // isMounted와 isDesktop, 그리고 ad-slot 변경 시에도 재시도
+
+  // 마운트 전에는 아무것도 렌더링하지 않음 (SSR 회피 및 초기 깜빡임 방지)
+  if (!isMounted) {
+    // console.log('AdSense: Not mounted yet');
+    return null
+  }
+
+  // 데스크톱이 아니면 수동 광고를 렌더링하지 않음 (자동 광고에 위임)
+  if (!isDesktop) {
+    // console.log('AdSense: Not desktop, returning null for manual ad.');
+    return null
+  }
+
+  if (!process.env.NEXT_PUBLIC_AD_CLIENT) {
+    console.error('AdSense client ID is missing.')
+    return null
+  }
+
+  return (
+    <ins
+      ref={adRef}
+      className={cn('adsbygoogle', 'block', className)}
+      data-ad-client={process.env.NEXT_PUBLIC_AD_CLIENT}
+      {...props}
+    />
+  )
+}
+
+export default GoogleAdSense

--- a/src/shared/ui/footer-ad-sense.tsx
+++ b/src/shared/ui/footer-ad-sense.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useEffect, useState, useRef } from 'react'
+
 import GoogleAdSense from '../lib/google-ad-sense'
 import { cn } from '../lib/tailwind-merge'
 import { useClient } from '../lib/use-client'
@@ -8,23 +10,51 @@ const isDev = process.env.NODE_ENV === 'development'
 
 const FooterAdSense = () => {
   const isClient = useClient()
+  const [breakpoint, setBreakpoint] = useState<Breakpoint>(getBreakpoint())
+  const prevBreakpointRef = useRef<Breakpoint>(breakpoint)
+
+  useEffect(() => {
+    const update = () => {
+      const current = getBreakpoint()
+      if (prevBreakpointRef.current !== current) {
+        prevBreakpointRef.current = current
+        setBreakpoint(current)
+      }
+    }
+
+    window.addEventListener('resize', update)
+    return () => window.removeEventListener('resize', update)
+  }, [])
 
   if (!isClient) return null
 
   if (isDev) {
-    return <div className={cn(AdSenseStyle, 'bg-slate-300')} />
+    return <div className={cn(AdStyle, 'bg-slate-300')} />
   }
 
   return (
     <GoogleAdSense
-      className={AdSenseStyle}
+      key={`footer-ad-${breakpoint}`} // key를 사용하여 광고를 강제로 다시 로드
+      className={AdStyle}
       data-ad-slot='4790060150'
       data-full-width-responsive='true'
     />
   )
 }
 
-const AdSenseStyle =
+const AdStyle =
   'mb-1 h-[90px] w-full max-w-[100vw] overflow-hidden rounded-sm tab:max-w-[728px]'
+
+type Breakpoint = 'ssr' | 'mobile' | 'tablet' | 'desktop'
+
+const getBreakpoint = (): Breakpoint => {
+  if (typeof window === 'undefined') return 'ssr'
+  const width = window.innerWidth
+
+  if (width < 726) return 'mobile'
+  if (width < 1377) return 'tablet'
+
+  return 'desktop'
+}
 
 export { FooterAdSense }

--- a/src/shared/ui/footer-ad-sense.tsx
+++ b/src/shared/ui/footer-ad-sense.tsx
@@ -5,6 +5,9 @@ import { useEffect, useState, useRef } from 'react'
 import GoogleAdSense from '../lib/google-ad-sense'
 import { cn } from '../lib/tailwind-merge'
 import { useClient } from '../lib/use-client'
+import { getBreakpoint } from '../lib/get-break-point'
+
+type Breakpoint = ReturnType<typeof getBreakpoint>
 
 const isDev = process.env.NODE_ENV === 'development'
 
@@ -44,17 +47,5 @@ const FooterAdSense = () => {
 
 const AdStyle =
   'mb-1 h-[90px] w-full max-w-[100vw] overflow-hidden rounded-sm tab:max-w-[728px]'
-
-type Breakpoint = 'ssr' | 'mobile' | 'tablet' | 'desktop'
-
-const getBreakpoint = (): Breakpoint => {
-  if (typeof window === 'undefined') return 'ssr'
-  const width = window.innerWidth
-
-  if (width < 726) return 'mobile'
-  if (width < 1377) return 'tablet'
-
-  return 'desktop'
-}
 
 export { FooterAdSense }

--- a/src/shared/ui/main-ad-sense.tsx
+++ b/src/shared/ui/main-ad-sense.tsx
@@ -4,6 +4,9 @@ import { useEffect, useState, useRef } from 'react'
 import GoogleAdSense from '../lib/google-ad-sense'
 import { cn } from '../lib/tailwind-merge'
 import { useClient } from '../lib/use-client'
+import { getBreakpoint } from '../lib/get-break-point'
+
+type Breakpoint = ReturnType<typeof getBreakpoint>
 
 const isDev = process.env.NODE_ENV === 'development'
 
@@ -43,16 +46,5 @@ const MainAdSense = () => {
 
 const AdStyle =
   'my-24 h-[37.5rem] w-40 place-content-center overflow-hidden rounded-sm pc:ml-5 pc:block'
-
-type Breakpoint = 'ssr' | 'mobile' | 'tablet' | 'desktop'
-
-const getBreakpoint = (): Breakpoint => {
-  if (typeof window === 'undefined') return 'ssr'
-  const width = window.innerWidth
-
-  if (width < 726) return 'mobile'
-  if (width < 1377) return 'tablet'
-  return 'desktop'
-}
 
 export { MainAdSense }

--- a/src/shared/ui/main-ad-sense.tsx
+++ b/src/shared/ui/main-ad-sense.tsx
@@ -1,33 +1,58 @@
 'use client'
 
+import { useEffect, useState, useRef } from 'react'
 import GoogleAdSense from '../lib/google-ad-sense'
 import { cn } from '../lib/tailwind-merge'
 import { useClient } from '../lib/use-client'
-import { useDesktop } from '../lib/use-desktop'
 
 const isDev = process.env.NODE_ENV === 'development'
-const NO_DELAY = 0 // 화면 크기 전환 시 지연 없이 렌더링하여, 데스크탑 전환 시 발생할 수 있는 느린 레이아웃 쉬프트 방지
 
 const MainAdSense = () => {
   const isClient = useClient()
-  const isDesktop = useDesktop(NO_DELAY)
+  const [breakpoint, setBreakpoint] = useState<Breakpoint>(getBreakpoint())
+  const prevBreakpointRef = useRef<Breakpoint>(breakpoint)
 
-  if (!isDesktop || !isClient) return null
+  useEffect(() => {
+    const update = () => {
+      const current = getBreakpoint()
+      if (prevBreakpointRef.current !== current) {
+        prevBreakpointRef.current = current
+        setBreakpoint(current)
+      }
+    }
 
-  if (isDev && isDesktop) {
-    return <div className={cn(AdSenseStyle, 'bg-slate-300')} />
+    window.addEventListener('resize', update)
+    return () => window.removeEventListener('resize', update)
+  }, [])
+
+  if (!isClient || breakpoint !== 'desktop') return null
+
+  if (isDev) {
+    return <div className={cn(AdStyle, 'bg-slate-300')} />
   }
 
   return (
     <GoogleAdSense
-      className={AdSenseStyle}
+      key={`main-ad-${breakpoint}`} // key를 사용하여 광고를 강제로 다시 로드
+      className={AdStyle}
       data-ad-slot='9725653724'
       data-full-width-responsive='true'
     />
   )
 }
 
-const AdSenseStyle =
-  'my-24 h-[37.5rem] w-40 place-content-center rounded-sm pc:ml-5 pc:block'
+const AdStyle =
+  'my-24 h-[37.5rem] w-40 place-content-center overflow-hidden rounded-sm pc:ml-5 pc:block'
+
+type Breakpoint = 'ssr' | 'mobile' | 'tablet' | 'desktop'
+
+const getBreakpoint = (): Breakpoint => {
+  if (typeof window === 'undefined') return 'ssr'
+  const width = window.innerWidth
+
+  if (width < 726) return 'mobile'
+  if (width < 1377) return 'tablet'
+  return 'desktop'
+}
 
 export { MainAdSense }


### PR DESCRIPTION
프로덕션과 리모트의 src/shared/lib/google-ad-sense.tsx 파일이 다른 상태로, 자세한 내용은 #208 이슈에 기재하였으며
프로덕션에 적용된 파일은 src/shared/lib/google-ad-sense-production.tsx 로 추가하였습니다. 
이 파일은 이력 관리 및 참고용으로만 사용되며, 광고 관련 기능이 안정화되면 제거할 예정입니다.

현재 PR에 포함된 수정 코드는 @jeongbaebang 님께서 프로덕션에 적용된 내용을 참고해 개선해 주셨습니다.🙂
아래는 정배님께 슬랙으로 공유 받은 변경 사항입니다.
- 반응형 광고 사이즈 문제 해결: 화면 크기 변경 시 광고가 다시 로드되도록 React key를 활용해 리렌더링 처리
- 모바일 광고 미출력 개선: 모바일 너비에서도 광고가 정상 노출되도록 조건 분기 로직 수정
- 광고 스크립트 안정성 확보: adsbygoogle이 준비될 때까지 polling 후 push, 불필요한 로직 제거로 코드 정리

close #208 