### PR TITLE
[#218] global-error 컴포넌트 간격 및 스타일 개선

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -7,7 +7,7 @@ export default function GlobalError() {
     <html lang='ko'>
       <body>
         <BaseLayout>
-          <div className='mx-4 my-12 flex w-full flex-col items-center justify-center rounded-2xl bg-white p-5 tab:m-[3.75rem]'>
+          <div className='mx-4 mb-12 mt-[3.065rem] flex w-full flex-col items-center justify-center rounded-lg bg-white p-5 tab:mx-[3.75rem] tab:mt-[3.875rem] tab:rounded-[1rem] pc:mx-0 pc:mt-[4.5rem]'>
             <h2 className='text-2xl font-semibold leading-[150%] tracking-tight tab:text-[2rem] pc:text-[3rem]'>
               오류가 발생했습니다
             </h2>


### PR DESCRIPTION
- 전역 에러 발생 시 렌더링되는 UI 컴포넌트의 레이아웃 및 간격을 조정하여, 전체 UI와의 일체감을 개선했습니다.

적용전 
![스크린샷 2025-05-14 오후 11 24 24](https://github.com/user-attachments/assets/da4676ee-205a-4a00-a100-0f80e2d9da02)

적용후
![스크린샷 2025-05-14 오후 11 22 53](https://github.com/user-attachments/assets/f2d5184d-c90e-43bb-bfbe-4038a9b6077b)

