### PR TITLE
[#217]: 뷰포트 기반 Google AdSense 광고 로딩 및 자동 재시도 로직 구현

### DIFF
--- a/src/shared/lib/google-ad-sense.tsx
+++ b/src/shared/lib/google-ad-sense.tsx
@@ -12,40 +12,79 @@ declare global {
 
 interface GoogleAdSenseProps {
   className?: string
+  onFilled?: () => void
+  onUnFilled?: () => void
 }
 
-const AD_STATUS_ATTR = 'data-adsbygoogle-status'
-const AD_LOAD_INTERVAL = 100 // 100ms 간격
-const MAX_ATTEMPTS = 50 // 5초간 최대 시도
+const AD_CONFIG = {
+  loadInterval: 100, // adsbygoogle 스크립트 polling 간격 (ms)
+  maxAttempts: 50, // polling 최대 시도 횟수 (약 5초 동안)
+  viewTrigger: 0.1, // 광고 요소가 뷰포트에 10% 이상 노출됐을 때만 로딩
+  status: {
+    key: 'data-ad-status',
+    filled: 'filled', // 광고가 성공적으로 채워진 경우
+    unFilled: 'unfilled', // 광고가 로드되지 않은 경우
+    detectTime: 1500, // push 이후 광고 로드 상태 감지까지 대기 시간 (ms)
+  },
+}
 
-const GoogleAdSense = ({ className, ...props }: GoogleAdSenseProps) => {
+const GoogleAdSense = ({
+  className,
+  onFilled,
+  onUnFilled,
+  ...restProps
+}: GoogleAdSenseProps) => {
+  const initializedRef = useRef(false) // 광고가 이미 push 되었는지 추적
   const adRef = useRef<HTMLModElement>(null)
+  const tryLoadAdGoogleTimerRef = useRef<NodeJS.Timeout>()
+  const checkAdStatusTimerRef = useRef<NodeJS.Timeout>()
 
   useEffect(() => {
-    if (!adRef.current) return
+    if (!adRef.current || initializedRef.current) return
 
-    // 광고 스크립트가 로드될 때까지 polling → 준비되면 광고 push
-    const timerId = tryLoadAdGoogle({
-      onAdReady: () => {
-        try {
-          const alreadyLoaded =
-            adRef.current?.getAttribute(AD_STATUS_ATTR) === 'done'
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        // 뷰포트에 요소가 충분히 들어오지 않았거나 이미 로드된 경우 무시
+        if (!entry.isIntersecting || initializedRef.current) return
 
-          if (!alreadyLoaded && window.adsbygoogle) {
-            window.adsbygoogle.push({})
-          }
-        } catch (e) {
-          console.error('Error pushing ad to AdSense:', e)
-        }
+        // 광고 스크립트가 로드될 때까지 polling → 준비되면 광고 push
+        tryLoadAdGoogleTimerRef.current = tryLoadAdGoogle({
+          onAdReady: () => {
+            try {
+              // 광고 요청: <ins> 요소에 광고 삽입 시도
+              ;(window.adsbygoogle = window.adsbygoogle || []).push({})
+              initializedRef.current = true
+
+              // 일정 시간 뒤 광고 로드 여부를 체크하여 콜백 호출
+              checkAdStatusTimerRef.current = setTimeout(() => {
+                const status = adRef.current?.getAttribute(AD_CONFIG.status.key)
+                checkAdStatus(status, { onUnFilled, onFilled })
+              }, AD_CONFIG.status.detectTime)
+            } catch (e) {
+              console.error('Error pushing ad to AdSense:', e)
+              onUnFilled?.()
+            }
+          },
+          onAdFail: () => {
+            console.warn('AdSense loading failed.')
+          },
+          maxAttempts: AD_CONFIG.maxAttempts,
+          retry: AD_CONFIG.loadInterval,
+        })
+
+        // 한 번 감지되면 observer 해제 (1회 감지 목적)
+        observer.disconnect()
       },
-      onAdFail: () => {
-        console.warn('AdSense loading failed, fallback will be rendered.')
-      },
-      maxAttempts: MAX_ATTEMPTS,
-      retry: AD_LOAD_INTERVAL,
-    })
+      { threshold: AD_CONFIG.viewTrigger },
+    )
 
-    return () => clearInterval(timerId)
+    observer.observe(adRef.current)
+
+    return () => {
+      observer.disconnect()
+      clearTimeout(checkAdStatusTimerRef.current)
+      clearInterval(tryLoadAdGoogleTimerRef.current)
+    }
   }, [])
 
   if (!process.env.NEXT_PUBLIC_AD_CLIENT) {
@@ -58,9 +97,25 @@ const GoogleAdSense = ({ className, ...props }: GoogleAdSenseProps) => {
       ref={adRef}
       className={cn('adsbygoogle', 'block', className)}
       data-ad-client={process.env.NEXT_PUBLIC_AD_CLIENT}
-      {...props}
+      {...restProps}
     />
   )
+}
+
+// 광고 로딩 결과 상태 체크 함수
+const checkAdStatus = (
+  status: string | null | undefined,
+  options: {
+    onFilled?: () => void
+    onUnFilled?: () => void
+  },
+) => {
+  if (status === AD_CONFIG.status.filled) {
+    return options.onFilled?.()
+  }
+
+  // filled가 아니거나 unknown일 경우에는 unfilled로 처리
+  return options.onUnFilled?.()
 }
 
 interface TryLoadAdGoogle {

--- a/src/shared/lib/use-ad-retry-key.ts
+++ b/src/shared/lib/use-ad-retry-key.ts
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react'
 
 export const useAdRetryKey = (
   prefix: string,
-  maxRetries: number = 3,
+  maxRetries: number,
 ): [string, number, () => void, () => void] => {
   const [retryCount, setRetryCount] = useState(0)
   const [key, setKey] = useState(() => `${prefix}-${Date.now()}`)

--- a/src/shared/lib/use-ad-retry-key.ts
+++ b/src/shared/lib/use-ad-retry-key.ts
@@ -1,0 +1,26 @@
+import { useCallback, useState } from 'react'
+
+export const useAdRetryKey = (
+  prefix: string,
+  maxRetries: number = 3,
+): [string, number, () => void, () => void] => {
+  const [retryCount, setRetryCount] = useState(0)
+  const [key, setKey] = useState(() => `${prefix}-${Date.now()}`)
+
+  const reset = useCallback(() => {
+    setRetryCount(0)
+    setKey(`${prefix}-${Date.now()}`)
+  }, [prefix])
+
+  const retry = useCallback(() => {
+    setRetryCount(prev => {
+      const next = prev + 1
+      if (next <= maxRetries) {
+        setKey(`${prefix}-retry-${next}-${Date.now()}`)
+      }
+      return next
+    })
+  }, [prefix, maxRetries])
+
+  return [key, retryCount, retry, reset]
+}

--- a/src/shared/lib/use-break-point.ts
+++ b/src/shared/lib/use-break-point.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef, useState } from 'react'
+import { getBreakpoint } from '../lib/get-break-point'
+
+type Breakpoint = ReturnType<typeof getBreakpoint>
+
+export const useBreakpoint = (): Breakpoint => {
+  const [breakpoint, setBreakpoint] = useState<Breakpoint>(getBreakpoint())
+  const prevBreakpointRef = useRef<Breakpoint>(breakpoint)
+
+  useEffect(() => {
+    const update = () => {
+      const current = getBreakpoint()
+      if (prevBreakpointRef.current !== current) {
+        prevBreakpointRef.current = current
+        setBreakpoint(current)
+      }
+    }
+
+    window.addEventListener('resize', update)
+    return () => window.removeEventListener('resize', update)
+  }, [])
+
+  return breakpoint
+}

--- a/src/shared/ui/footer-ad-sense.tsx
+++ b/src/shared/ui/footer-ad-sense.tsx
@@ -47,8 +47,8 @@ const FooterAdSense = () => {
       className={AdStyle}
       data-ad-slot='4790060150'
       data-full-width-responsive='true'
-      onFilled={handleFilled}
-      onUnFilled={handleUnFilled}
+      onAdFilled={handleFilled}
+      onAdUnfilled={handleUnFilled}
     />
   )
 }

--- a/src/shared/ui/footer-ad-sense.tsx
+++ b/src/shared/ui/footer-ad-sense.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
 
 import GoogleAdSense from '../lib/google-ad-sense'
 import { cn } from '../lib/tailwind-merge'
@@ -12,16 +13,17 @@ const MAX_RETRIES = 3
 const isDev = process.env.NODE_ENV === 'development'
 
 const FooterAdSense = () => {
+  const pathname = usePathname()
   const isClient = useClient()
   const breakpoint = useBreakpoint()
   const [adKey, retryCount, retry, reset] = useAdRetryKey(
-    `footer-ad-${breakpoint}`,
+    `footer-ad-${pathname}-${breakpoint}`,
     MAX_RETRIES,
   )
 
   useEffect(() => {
-    reset() // breakpoint가 변경될 때 광고 키 리셋
-  }, [breakpoint])
+    reset()
+  }, [pathname, breakpoint])
 
   const handleUnFilled = () => {
     if (retryCount < MAX_RETRIES) {

--- a/src/shared/ui/main-ad-sense.tsx
+++ b/src/shared/ui/main-ad-sense.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
 
 import GoogleAdSense from '../lib/google-ad-sense'
 import { cn } from '../lib/tailwind-merge'
@@ -12,16 +13,17 @@ const MAX_RETRIES = 3
 const isDev = process.env.NODE_ENV === 'development'
 
 const MainAdSense = () => {
+  const pathname = usePathname()
   const isClient = useClient()
   const breakpoint = useBreakpoint()
   const [adKey, retryCount, retry, reset] = useAdRetryKey(
-    `main-ad-${breakpoint}`,
+    `main-ad-${pathname}-${breakpoint}`,
     MAX_RETRIES,
   )
 
   useEffect(() => {
-    reset() // breakpoint가 변경될 때 광고 키 리셋
-  }, [breakpoint])
+    reset()
+  }, [pathname, breakpoint])
 
   const handleUnFilled = () => {
     if (retryCount < MAX_RETRIES) {

--- a/src/shared/ui/main-ad-sense.tsx
+++ b/src/shared/ui/main-ad-sense.tsx
@@ -48,8 +48,8 @@ const MainAdSense = () => {
       className={AdStyle}
       data-ad-slot='9725653724'
       data-full-width-responsive='true'
-      onFilled={handleFilled}
-      onUnFilled={handleUnFilled}
+      onAdFilled={handleFilled}
+      onAdUnfilled={handleUnFilled}
     />
   )
 }

--- a/src/shared/ui/main-ad-sense.tsx
+++ b/src/shared/ui/main-ad-sense.tsx
@@ -1,32 +1,40 @@
 'use client'
 
-import { useEffect, useState, useRef } from 'react'
+import { useEffect } from 'react'
+
 import GoogleAdSense from '../lib/google-ad-sense'
 import { cn } from '../lib/tailwind-merge'
 import { useClient } from '../lib/use-client'
-import { getBreakpoint } from '../lib/get-break-point'
+import { useBreakpoint } from '../lib/use-break-point'
+import { useAdRetryKey } from '../lib/use-ad-retry-key'
 
-type Breakpoint = ReturnType<typeof getBreakpoint>
-
+const MAX_RETRIES = 3
 const isDev = process.env.NODE_ENV === 'development'
 
 const MainAdSense = () => {
   const isClient = useClient()
-  const [breakpoint, setBreakpoint] = useState<Breakpoint>(getBreakpoint())
-  const prevBreakpointRef = useRef<Breakpoint>(breakpoint)
+  const breakpoint = useBreakpoint()
+  const [adKey, retryCount, retry, reset] = useAdRetryKey(
+    `main-ad-${breakpoint}`,
+    MAX_RETRIES,
+  )
 
   useEffect(() => {
-    const update = () => {
-      const current = getBreakpoint()
-      if (prevBreakpointRef.current !== current) {
-        prevBreakpointRef.current = current
-        setBreakpoint(current)
-      }
-    }
+    reset() // breakpoint가 변경될 때 광고 키 리셋
+  }, [breakpoint])
 
-    window.addEventListener('resize', update)
-    return () => window.removeEventListener('resize', update)
-  }, [])
+  const handleUnFilled = () => {
+    if (retryCount < MAX_RETRIES) {
+      retry()
+      console.warn(`🔁 광고 재시도: ${retryCount + 1}/${MAX_RETRIES}`)
+    } else {
+      console.warn('🛑 광고 재시도 최대 도달 – fallback 고려')
+    }
+  }
+
+  const handleFilled = () => {
+    console.log('✅ 메인 광고 성공적으로 로드됨')
+  }
 
   if (!isClient || breakpoint !== 'desktop') return null
 
@@ -36,10 +44,12 @@ const MainAdSense = () => {
 
   return (
     <GoogleAdSense
-      key={`main-ad-${breakpoint}`} // key를 사용하여 광고를 강제로 다시 로드
+      key={adKey}
       className={AdStyle}
       data-ad-slot='9725653724'
       data-full-width-responsive='true'
+      onFilled={handleFilled}
+      onUnFilled={handleUnFilled}
     />
   )
 }


### PR DESCRIPTION
#### 주요 변경사항
- 간헐적으로 data-ad-status="unfilled" 상태에 도달할 경우 광고가 더 이상 로드되지 않는 문제를 해결했습니다.
→ 광고 컴포넌트를 최대 3회까지 자동 재시도하여 새로고침 없이도 광고가 노출될 수 있도록 개선하였습니다.
- 광고가 사용자의 뷰포트에 실제로 진입했을 때만 로드되도록 최적화하여, 초기 로딩 성능 개선 및 UX 향상을 유도했습니다.
- 중복 로직을 useBreakpoint, useAdRetryKey 등의 커스텀 훅으로 분리하여 재사용성과 유지보수성을 높였습니다.
- 모바일 환경에서 광고 게재율 테스트를 위해 최소 높이 및 너비 기준을 임시 조정했습니다.
- 상태가 `filled` 또는 `unfilled`로 확인되면 즉시 처리 후 폴링을 중단하도록 최적화하였습니다.
- 불필요한 반복을 방지하고, 광고 로드 성공 여부를 빠르게 판별할 수 있도록 개선했습니다.
- SPA 전환 환경에서도 광고가 정상적으로 갱신되어 수익 누락 방지하도록 처리하였습니다.

#### 데모영상

https://github.com/user-attachments/assets/8e769feb-2a80-452a-b5f2-763207078658

⸻

#### Google AdSense 포함된 기능
-  IntersectionObserver 기반: 뷰포트 진입 시에만 광고 로딩
- adsbygoogle 스크립트 준비 여부를 polling하여 정확한 push 시점 제어
- 광고 push 후 data-ad-status 값을 통해 실제 광고 로드 성공 여부 판단
- onAdFilled, onAdUnfilled 콜백을 통해 광고 상태 외부에서 핸들링 가능
- key 변경을 통해 컴포넌트 리마운트 → 강제 재시도 가능

⸻

#### 개별 광고 컴포넌트 기능

MainAdSense
- desktop 환경에서만 렌더링
- 광고 실패 시 최대 3회까지 자동 재시도
- breakpoint 변경 시 자동 광고 리셋

FooterAdSense
- 모든 해상도에서 출력
- 광고 실패 시 최대 3회까지 자동 재시도
- 동일한 재시도 및 리셋 로직 적용

⸻

#### 구조적 개선
- 광고 로딩 로직의 핵심은 GoogleAdSense 단일 컴포넌트로 통합
- 광고 위치별 로직(Main/Footer)은 최소화하여 유지보수 용이
- 재사용 가능한 커스텀 훅 도입
- useBreakpoint: 반응형 breakpoint 감지
- useAdRetryKey: 광고 리렌더링을 위한 key 및 재시도 횟수 관리

⸻

#### 추가 고려사항
- window.adsbygoogle이 존재하지 않는 경우에도 안전하게 초기화
- initializedRef로 중복 push 방지
- setTimeout, setInterval, IntersectionObserver 모두 clean-up 처리 완비

⸻

Ref 
- #212 