### PR TITLE
[#223] 광고 영역 개선 및 반응형 레이아웃 정비

### DIFF
--- a/app/order/layout.tsx
+++ b/app/order/layout.tsx
@@ -6,7 +6,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className='grid min-h-screen grid-rows-[auto_1fr_auto] bg-white'>
       <Header />
-      <div className='flex bg-white px-6 pc:container tab:px-[3.75rem] pc:mx-auto pc:px-[3.5rem]'>
+      <div className='flex bg-white px-6 pc:container pc-lg:container tab:px-[3.75rem] pc:mx-auto pc:px-[3.5rem]'>
         {/* 레이아웃 쉬프트 방지 */}
         <div className='flex h-full flex-1'>{children}</div>
       </div>

--- a/components.json
+++ b/components.json
@@ -11,8 +11,8 @@
     "prefix": ""
   },
   "aliases": {
-    "components": "@/shared/components",
-    "utils": "@/shared/lib/utils",
+    "components": "@/shared/ui",
+    "utils": "@/shared/lib/tailwind-merge.ts",
     "ui": "@/shared/ui",
     "lib": "@/shared/lib",
     "hooks": "@/shared/lib"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,12 +32,14 @@
         "sharp": "^0.33.5",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
+        "ua-parser-js": "^2.0.3",
         "zod": "^3.24.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.6.1",
         "@commitlint/config-conventional": "^19.6.0",
         "@svgr/webpack": "^8.1.0",
+        "@tailwindcss/container-queries": "^0.1.1",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -3831,6 +3833,16 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tailwindcss/container-queries": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz",
+      "integrity": "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.2.0"
+      }
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "dev": true,
@@ -3854,10 +3866,19 @@
     },
     "node_modules/@types/node": {
       "version": "20.17.19",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -5178,6 +5199,26 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.0.3",
@@ -7300,6 +7341,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "dev": true,
@@ -7962,6 +8023,26 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-releases": {
@@ -9918,6 +9999,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.0.1",
       "dev": true,
@@ -10084,6 +10171,59 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.3.tgz",
+      "integrity": "sha512-LZyXZdNttONW8LjzEH3Z8+6TE7RfrEiJqDKyh0R11p/kxvrV2o9DrT2FGZO+KVNs3k+drcIQ6C3En6wLnzJGpw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@types/node-fetch": "^2.6.12",
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "node-fetch": "^2.7.0",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "dev": true,
@@ -10103,7 +10243,6 @@
     },
     "node_modules/undici-types": {
       "version": "6.19.8",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -10239,6 +10378,22 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -37,12 +37,14 @@
     "sharp": "^0.33.5",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
+    "ua-parser-js": "^2.0.3",
     "zod": "^3.24.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.1",
     "@commitlint/config-conventional": "^19.6.0",
     "@svgr/webpack": "^8.1.0",
+    "@tailwindcss/container-queries": "^0.1.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,7 +1,6 @@
 import 'overlayscrollbars/overlayscrollbars.css'
 import './styles/globals.css'
 
-import Script from 'next/script'
 import localFont from 'next/font/local'
 import { Toaster } from '@/shared/ui/toaster'
 
@@ -21,11 +20,10 @@ const App = ({
     <html lang='ko' className={`${pretendard.variable}`}>
       <head>
         {/* Google AdSense */}
-        <Script
+        <script
           async
           src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${process.env.NEXT_PUBLIC_AD_CLIENT}`}
           crossOrigin='anonymous'
-          strategy='afterInteractive'
         />
       </head>
       <body className={`${pretendard.className} antialiased`}>

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -82,11 +82,6 @@ body {
     --os-track-border-radius: 4px;
   }
 
-  [contenteditable='true']:empty:before {
-    content: attr(data-placeholder);
-    pointer-events: none;
-  }
-
   * {
     @apply border-border;
   }

--- a/src/pages/feedback/ui/submitted-page.tsx
+++ b/src/pages/feedback/ui/submitted-page.tsx
@@ -32,9 +32,9 @@ const SubmittedPage = async ({
       />
       <Image
         src={submittedWebImage}
-        alt='submitted_tab'
+        alt='submitted_web'
         sizes='100vw'
-        className='hidden h-auto w-full bg-background pc:block'
+        className='hidden h-auto w-full self-center bg-background pc:block pc:rounded-sm pc-lg:rounded-none'
       />
       <div className='-mt-28 space-y-7 px-4 tab:-mt-28 tab:space-y-8 tab:px-[3.75rem] pc:-mt-0 pc:max-w-[36.25rem] pc:space-y-0 pc:px-0 pc:pl-[2.25rem] pc:pt-[6.125rem]'>
         {/* 의견 제출 성공 메시지 */}

--- a/src/pages/guide/ui/pc-guide.tsx
+++ b/src/pages/guide/ui/pc-guide.tsx
@@ -11,7 +11,7 @@ export const PcGuide = () => {
         height={1200}
         alt='누구나 제한 없이 전문적인 맞춤법을 사용해요.'
       />
-      <div className='px-4 pc:container pc:mx-auto pc:px-[4.5rem]'>
+      <div className='px-4 pc:container pc-lg:container pc:mx-auto pc:px-[4.5rem]'>
         <h2 className='pb-[1.875rem] pt-[4.375rem] text-center text-3xl font-bold text-slate-400'>
           바른 한글 사용법
         </h2>

--- a/src/pages/guide/ui/tab-mobile-guide.tsx
+++ b/src/pages/guide/ui/tab-mobile-guide.tsx
@@ -12,7 +12,7 @@ export const TabMobileGuide = () => {
           alt='누구나 제한 없이 전문적인 맞춤법을 사용해요.'
         />
       </div>
-      <div className='px-4 pc:container pc:mx-auto pc:px-[4.5rem]'>
+      <div className='px-4 pc:container pc-lg:container pc:mx-auto pc:px-[4.5rem]'>
         <h2 className='pb-[1.875rem] pt-[4.375rem] text-center text-xl font-bold text-slate-400 tab:text-3xl'>
           바른 한글 사용법
         </h2>

--- a/src/pages/results/ui/error-tracking-section.tsx
+++ b/src/pages/results/ui/error-tracking-section.tsx
@@ -48,30 +48,28 @@ const ErrorTrackingSection = () => {
           ))}
         </div>
       </ScrollContainer>
-      <div>
-        <div className='flex items-center gap-4 text-sm font-medium'>
-          <span className='flex items-center gap-2 tab:text-lg'>
-            <BulletBadge
-              method={CorrectMethodEnum.enum.띄어쓰기}
-              className='tab:size-3'
-            />
-            띄어쓰기 오류
-          </span>
-          <span className='flex items-center gap-2 tab:text-lg'>
-            <BulletBadge
-              method={CorrectMethodEnum.enum.오탈자}
-              className='tab:size-3'
-            />
-            오탈자 오류
-          </span>
-          <span className='flex items-center gap-2 tab:text-lg'>
-            <BulletBadge
-              method={CorrectMethodEnum.enum.문맥}
-              className='tab:size-3'
-            />
-            문맥상 오류
-          </span>
-        </div>
+      <div className='flex items-center gap-4 pt-5 text-sm font-medium pc:-translate-y-5 pc:justify-between pc:gap-0 pc:@[400px]:justify-normal pc:@[400px]:gap-4'>
+        <span className='flex items-center gap-2 tab:text-lg pc:gap-1 pc:@[400px]:gap-2'>
+          <BulletBadge
+            method={CorrectMethodEnum.enum.띄어쓰기}
+            className='tab:size-3'
+          />
+          띄어쓰기 오류
+        </span>
+        <span className='flex items-center gap-2 tab:text-lg pc:gap-1 pc:@[400px]:gap-2'>
+          <BulletBadge
+            method={CorrectMethodEnum.enum.오탈자}
+            className='tab:size-3'
+          />
+          오탈자 오류
+        </span>
+        <span className='flex items-center gap-2 tab:text-lg pc:gap-1 pc:@[400px]:gap-2'>
+          <BulletBadge
+            method={CorrectMethodEnum.enum.문맥}
+            className='tab:size-3'
+          />
+          문맥상 오류
+        </span>
       </div>
     </>
   )

--- a/src/pages/results/ui/help-section.tsx
+++ b/src/pages/results/ui/help-section.tsx
@@ -3,9 +3,11 @@ import {
   useDebounce,
   useWindowSize,
 } from '@frontend-opensource/use-react-hooks'
+
 import { Button } from '@/shared/ui/button'
 import { cn } from '@/shared/lib/tailwind-merge'
 import ArrowBottomIcon from '@/shared/ui/icon/icon-arrow-bottom.svg'
+import { DESKTOP, TABLET } from '../../../../tailwind.config'
 
 interface HelpSectionProps {
   help: string
@@ -23,8 +25,8 @@ const HelpSection = ({ help }: HelpSectionProps) => {
     const rem = 16
     // threshold: 각 디바이스 화면에서 도움말이 2줄까지 보이는 높이
     let threshold = 4.5 * rem // mobile
-    if (width! >= 726) threshold = 3.5 * rem // tab
-    if (width! >= 1377) threshold = 3 * rem // pc
+    if (width! >= TABLET) threshold = 3.5 * rem // tab
+    if (width! >= DESKTOP) threshold = 3 * rem // pc
 
     setShowButton(contentRef.current.scrollHeight > threshold)
   }, 300)

--- a/src/pages/results/ui/results-control.tsx
+++ b/src/pages/results/ui/results-control.tsx
@@ -38,8 +38,8 @@ const ResultsControl = () => {
   }
 
   return (
-    <div className='mt-2 flex flex-shrink-0 justify-between'>
-      <TextCounter count={str.length} />
+    <div className='flex flex-shrink-0 justify-between pt-5'>
+      <TextCounter count={str.length} className='pc:-translate-y-3' />
       <div className='flex gap-3'>
         <ActionButton
           icon='/arrow-return-left.svg'

--- a/src/pages/results/ui/results-page.tsx
+++ b/src/pages/results/ui/results-page.tsx
@@ -5,30 +5,38 @@ import { StrongCheckMessage } from './strong-check-message'
 import { CorrectionContent } from './correction-content'
 import { ResultsControl } from './results-control'
 import { ErrorTrackingSection } from './error-tracking-section'
+import { cn } from '@/shared/lib/tailwind-merge'
+
 const ResultsPage = () => {
   return (
-    <ContentLayout className='pb-8 tab:pb-[2.625rem] pc:pb-12'>
-      <SpellerRefsProvider>
+    <SpellerRefsProvider>
+      <ContentLayout className='pb-8 tab:pb-[2.625rem] pc:pb-12'>
         <div className='relative mb-2 mt-[0.94rem] flex min-h-[1.625rem] items-center justify-between tab:mt-[1.75rem] tab:justify-center pc:mb-[0.78rem] pc:mt-[1.97rem] pc:min-h-8'>
           <Navigator />
           <StrongCheckMessage />
         </div>
         {/* 교정 문서 & 맞춤법/문법 오류 레이아웃*/}
-        <div className='flex flex-col gap-2 overflow-auto pc:flex-row pc:gap-0'>
+        <div className='flex h-full flex-col gap-2 overflow-hidden pc:flex-row pc:gap-0'>
           {/* 교정 문서*/}
-          <div className='flex max-h-[30.5rem] min-h-[30.5rem] w-full flex-1 flex-col rounded-lg bg-white p-5 tab:rounded-[1rem] tab:p-10 pc:max-h-[40.25rem] pc:w-1/2 pc:flex-none pc:rounded-br-none pc:rounded-tr-none'>
+          <div className='content-visibility-auto flex min-h-[30.5rem] flex-col rounded-lg bg-white p-5 contain-strict tab:rounded-[1rem] tab:p-10 pc:w-1/2 pc:rounded-br-none pc:rounded-tr-none pc:pr-[1.25rem] pc-lg:pr-10'>
             <CorrectionContent />
             {/* 글자수 & 돌아가기, 복사하기 버튼 */}
             <ResultsControl />
           </div>
           {/* 맞춤법/문법 오류 */}
-          <div className='flex max-h-[30.5rem] min-h-[30.5rem] w-full flex-1 flex-col rounded-lg border border-blue-500 bg-white px-5 pb-3.5 pt-[1.125rem] tab:rounded-[1rem] tab:p-10 tab:pb-7 pc:max-h-[40.25rem] pc:w-1/2 pc:flex-none pc:rounded-bl-none pc:rounded-tl-none pc:border-none pc:pb-10'>
+          <div
+            className={cn(
+              'content-visibility-auto flex min-h-[30.5rem] flex-col rounded-lg border border-blue-500 bg-white px-5 pb-3.5 pt-[1.125rem] contain-strict tab:rounded-[1rem] tab:p-10 tab:pb-7 pc:w-1/2 pc:rounded-bl-none pc:rounded-tl-none pc:border-none pc:pb-10 pc:pl-[1.25rem] pc-lg:pl-10',
+              '@container',
+            )}
+          >
             <ErrorTrackingSection />
           </div>
         </div>
-      </SpellerRefsProvider>
-    </ContentLayout>
+      </ContentLayout>
+    </SpellerRefsProvider>
   )
 }
 
+// 0.625rem
 export { ResultsPage }

--- a/src/pages/speller/ui/results-skeleton.tsx
+++ b/src/pages/speller/ui/results-skeleton.tsx
@@ -8,8 +8,8 @@ const ResultsSkeleton = () => {
       <div className='mb-2 mt-[0.94rem] flex min-h-[1.625rem] items-center justify-end tab:mt-[1.75rem] pc:mb-[0.78rem] pc:mt-[1.97rem] pc:min-h-8'>
         <Skeleton className='h-6 w-56 rounded-sm pc:h-[1.875rem] pc:w-64' />
       </div>
-      <div className='flex flex-col gap-2 overflow-auto pc:flex-row pc:gap-0'>
-        <div className='flex max-h-[30.5rem] min-h-[30.5rem] w-full flex-1 flex-col rounded-lg bg-white p-5 tab:rounded-[1rem] tab:p-10 pc:max-h-[40.25rem] pc:rounded-br-none pc:rounded-tr-none'>
+      <div className='flex h-full flex-col gap-2 overflow-hidden pc:flex-row pc:gap-0'>
+        <div className='content-visibility-auto flex min-h-[30.5rem] flex-col rounded-lg bg-white p-5 contain-strict tab:rounded-[1rem] tab:p-10 pc:w-1/2 pc:rounded-br-none pc:rounded-tr-none'>
           <div className='mb-[1rem] flex justify-between tab:mb-[1.25rem]'>
             <Skeleton className='h-7 w-16 rounded-sm tab:h-8 tab:w-20' />
           </div>
@@ -24,7 +24,7 @@ const ResultsSkeleton = () => {
             </div>
           </div>
         </div>
-        <div className='flex max-h-[30.5rem] min-h-[30.5rem] w-full flex-1 flex-col rounded-lg border border-blue-500 bg-white px-5 pb-3.5 pt-[1.125rem] tab:rounded-[1rem] tab:p-10 tab:pb-7 pc:max-h-[40.25rem] pc:rounded-bl-none pc:rounded-tl-none pc:border-none pc:pb-10'>
+        <div className='content-visibility-auto flex min-h-[30.5rem] flex-col rounded-lg border border-blue-500 bg-white px-5 pb-3.5 pt-[1.125rem] contain-strict tab:rounded-[1rem] tab:p-10 tab:pb-7 pc:w-1/2 pc:rounded-bl-none pc:rounded-tl-none pc:border-none pc:pb-10'>
           <div className='pb-[1.125rem]'>
             <Skeleton className='h-7 w-44 rounded-sm tab:h-8 tab:w-48' />
           </div>

--- a/src/pages/speller/ui/speller-page.tsx
+++ b/src/pages/speller/ui/speller-page.tsx
@@ -62,12 +62,12 @@ const SpellerPage = () => {
   return (
     <>
       <form action={formAction} className='flex-1'>
-        <ContentLayout className='pb-9 tab:pb-40 pc:pb-[3.06rem]'>
+        <ContentLayout className='min-h-[35.75rem] pb-9 pc:pb-[3.125rem]'>
           {/* 강한 검사 */}
           <div className='mb-2 mt-[0.94rem] min-h-[1.625rem] tab:mt-[1.75rem] pc:mb-[0.78rem] pc:mt-[1.97rem] pc:min-h-8'>
             <SpellerSetting />
           </div>
-          <div className='flex h-full w-full flex-col rounded-lg bg-white p-5 tab:rounded-[1rem] tab:p-10 pc:max-h-[40.25rem]'>
+          <div className='flex h-full w-full flex-col rounded-lg bg-white p-5 tab:rounded-[1rem] tab:p-10'>
             <SpellerTextInput />
             {/* 글자수 & 검사하기 버튼 */}
             <SpellerControl />

--- a/src/shared/lib/get-break-point.ts
+++ b/src/shared/lib/get-break-point.ts
@@ -1,11 +1,14 @@
-type Breakpoint = 'ssr' | 'mobile' | 'tablet' | 'desktop'
+import { DESKTOP, LARGE_DESKTOP, TABLET } from '../../../tailwind.config'
+
+type Breakpoint = 'ssr' | 'mobile' | 'tablet' | 'desktop' | 'desktop-small'
 
 const getBreakpoint = (): Breakpoint => {
   if (typeof window === 'undefined') return 'ssr'
   const width = window.innerWidth
 
-  if (width < 726) return 'mobile'
-  if (width < 1377) return 'tablet'
+  if (width < TABLET) return 'mobile'
+  if (width < DESKTOP) return 'tablet'
+  if (width < LARGE_DESKTOP) return 'desktop-small'
 
   return 'desktop'
 }

--- a/src/shared/lib/google-ad-sense-script.tsx
+++ b/src/shared/lib/google-ad-sense-script.tsx
@@ -1,0 +1,18 @@
+import Script from 'next/script'
+
+const GoogleAdsenseScript = () => {
+  if (process.env.NODE_ENV !== 'production') {
+    return null
+  }
+
+  return (
+    <Script
+      async
+      src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${process.env.NEXT_PUBLIC_AD_CLIENT}`}
+      strategy='lazyOnload'
+      crossOrigin='anonymous'
+    />
+  )
+}
+
+export { GoogleAdsenseScript }

--- a/src/shared/lib/google-ad-sense.tsx
+++ b/src/shared/lib/google-ad-sense.tsx
@@ -100,7 +100,7 @@ const GoogleAdSense = ({
   return (
     <ins
       ref={adRef}
-      className={cn('adsbygoogle', 'block', className)}
+      className={cn('adsbygoogle block min-h-[6.25rem]', className)}
       data-ad-client={process.env.NEXT_PUBLIC_AD_CLIENT}
       {...restProps}
     />

--- a/src/shared/lib/use-desktop.ts
+++ b/src/shared/lib/use-desktop.ts
@@ -1,12 +1,14 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useWindowSize } from '@frontend-opensource/use-react-hooks'
 
-const DELAY_MS = 1000 // 1초
-const DESKTOP_SIZE = 1377 // 데스크탑 너비
+import { DESKTOP } from '../../../tailwind.config'
+import { UAParser } from 'ua-parser-js'
 
-const isDesktopWidth = (width: number) => width >= DESKTOP_SIZE
+const DELAY_MS = 1000 // 1초
+
+const isDesktopWidth = (width: number) => width >= DESKTOP
 
 const useDesktop = (delayTime?: number) => {
   const { width } = useWindowSize(delayTime ?? DELAY_MS)
@@ -16,4 +18,16 @@ const useDesktop = (delayTime?: number) => {
   return isDesktop
 }
 
-export { useDesktop }
+const useDesktopDevice = () => {
+  const [isDesktop, setIsDesktop] = useState(true)
+
+  useEffect(() => {
+    const parser = new UAParser()
+    const result = parser.getResult()
+    setIsDesktop(!result.device.type)
+  }, [])
+
+  return isDesktop
+}
+
+export { useDesktop, useDesktopDevice }

--- a/src/shared/model/ad-context.tsx
+++ b/src/shared/model/ad-context.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import {
+  createContext,
+  useContext,
+  useState,
+  PropsWithChildren,
+  FC,
+  useCallback,
+} from 'react'
+
+type AdState = {
+  isAdFilled: boolean
+  isLoading: boolean
+  isDoneAd: boolean
+}
+
+type AdContextType = {
+  adState: AdState
+  resetAdState: () => void
+  readyAdState: () => void
+  failAdState: () => void
+}
+
+const AdContext = createContext<AdContextType | null>(null)
+
+const AdProvider: FC<PropsWithChildren> = ({ children }) => {
+  const [adState, setAdStateInternal] = useState<AdState>({
+    isAdFilled: false,
+    isLoading: true,
+    isDoneAd: false,
+  })
+
+  const setAdState = (next: Partial<AdState>) =>
+    setAdStateInternal(prev => ({ ...prev, ...next }))
+
+  const resetAdState = useCallback(() => {
+    setAdState({
+      isAdFilled: true,
+      isLoading: true,
+      isDoneAd: false,
+    })
+  }, [])
+
+  const readyAdState = useCallback(() => {
+    setAdState({
+      isAdFilled: true,
+      isLoading: false,
+      isDoneAd: false,
+    })
+  }, [])
+
+  const failAdState = useCallback(() => {
+    setAdState({
+      isAdFilled: false,
+      isLoading: false,
+      isDoneAd: true,
+    })
+  }, [])
+
+  return (
+    <AdContext.Provider
+      value={{ adState, resetAdState, readyAdState, failAdState }}
+    >
+      {children}
+    </AdContext.Provider>
+  )
+}
+
+export const useAdContext = () => {
+  const context = useContext(AdContext)
+
+  if (!context) {
+    throw new Error('useAdContext must be used within AdStatusProvider')
+  }
+
+  return context
+}
+
+export { AdProvider }

--- a/src/shared/ui/base-layout.tsx
+++ b/src/shared/ui/base-layout.tsx
@@ -6,9 +6,9 @@ import { MainAdSense } from './main-ad-sense'
 
 const BaseLayout: FC<PropsWithChildren> = ({ children }) => {
   return (
-    <div className='grid min-h-screen grid-rows-[auto_1fr_auto] bg-background'>
+    <div className='grid min-h-screen grid-rows-[auto_1fr_auto] bg-slate-200 pc:bg-background'>
       <Header />
-      <div className='flex bg-background pc:container pc:mx-auto pc:px-[4.5rem]'>
+      <div className='flex bg-background pc:container pc-lg:container pc:mx-auto pc:px-[2.25rem] pc-lg:px-[4.5rem]'>
         {/* 레이아웃 쉬프트 방지 */}
         <div className='flex h-full flex-1'>{children}</div>
         {/* 광고 영역 */}

--- a/src/shared/ui/footer-ad-sense.tsx
+++ b/src/shared/ui/footer-ad-sense.tsx
@@ -8,21 +8,41 @@ import { cn } from '../lib/tailwind-merge'
 import { useClient } from '../lib/use-client'
 import { useBreakpoint } from '../lib/use-break-point'
 import { useAdRetryKey } from '../lib/use-ad-retry-key'
+import { useAdContext } from '../model/ad-context'
+import { Skeleton } from './skeleton'
+import { useDesktopDevice } from '../lib/use-desktop'
 
 const MAX_RETRIES = 3
 const isDev = process.env.NODE_ENV === 'development'
 
 const FooterAdSense = () => {
+  const {
+    adState: { isAdFilled, isDoneAd, isLoading },
+    resetAdState,
+    readyAdState,
+    failAdState,
+  } = useAdContext()
   const pathname = usePathname()
   const isClient = useClient()
   const breakpoint = useBreakpoint()
+  const isDesktop = useDesktopDevice()
   const [adKey, retryCount, retry, reset] = useAdRetryKey(
     `footer-ad-${pathname}-${breakpoint}`,
     MAX_RETRIES,
   )
+  // 광고 로딩은 완료되었으나, 표시할 광고가 없는 상태
+  const isAdUnFilledStatus = !isAdFilled && isDoneAd
+  // 모바일에서는 반복적인 깜빡임 이슈로 스켈레톤 비활성화 → 데스크톱에서만 표시
+  const showSkeletonOnDesktopOnly = isLoading && isDesktop
 
   useEffect(() => {
     reset()
+    resetAdState()
+
+    return () => {
+      reset()
+      resetAdState()
+    }
   }, [pathname, breakpoint])
 
   const handleUnFilled = () => {
@@ -31,31 +51,58 @@ const FooterAdSense = () => {
       console.warn(`🔁 광고 재시도: ${retryCount + 1}/${MAX_RETRIES}`)
     } else {
       console.warn('🛑 광고 재시도 최대치 도달 — fallback 고려')
+      failAdState()
     }
   }
 
   const handleFilled = () => {
     console.log('✅ 광고 성공적으로 로드됨')
+    readyAdState()
   }
 
   if (!isClient) return null
 
   if (isDev) {
-    return <div className={cn(AdStyle, 'bg-slate-300')} />
+    return (
+      <div className={AdContainerStyle}>
+        <div className={cn(AdStyle, 'min-h-[6.25rem] bg-slate-300')}></div>
+      </div>
+    )
   }
+
   return (
-    <GoogleAdSense
-      key={adKey}
-      className={AdStyle}
-      data-ad-slot='4790060150'
-      data-full-width-responsive='true'
-      onAdFilled={handleFilled}
-      onAdUnfilled={handleUnFilled}
-    />
+    <div className={cn(AdContainerStyle, isAdUnFilledStatus && 'hidden')}>
+      {/* 광고 로딩 UI */}
+      {showSkeletonOnDesktopOnly ? (
+        <Skeleton
+          className={cn(
+            AdStyle,
+            'min-h-[6.25rem] rounded-none bg-slate-300 pc-lg:min-w-[45.5rem]',
+          )}
+        />
+      ) : null}
+      <div
+        className={cn(
+          'transition-opacity',
+          isLoading ? 'pointer-events-none opacity-0' : 'opacity-100',
+        )}
+      >
+        <GoogleAdSense
+          key={`${adKey}-${retryCount}`}
+          className={AdStyle}
+          data-ad-slot='4790060150'
+          data-full-width-responsive='true'
+          onAdFilled={handleFilled}
+          onAdUnfilled={handleUnFilled}
+        />
+      </div>
+    </div>
   )
 }
 
+const AdContainerStyle =
+  'fixed bottom-0 flex h-full max-h-[6.25rem] min-h-[6.25rem] w-full items-center justify-center overflow-hidden bg-transparent pc:static pc:justify-end pc:rounded-sm'
 const AdStyle =
-  'mb-1 h-[6.25rem] w-full max-w-[31.25rem] overflow-hidden rounded-sm tab:max-w-[728px]'
+  'h-auto w-full max-w-[31.25rem] self-center overflow-hidden tab:max-w-[45.5rem] tab:rounded-sm'
 
 export { FooterAdSense }

--- a/src/shared/ui/footer-ad-wrapper.tsx
+++ b/src/shared/ui/footer-ad-wrapper.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { cn } from '@/shared/lib/tailwind-merge'
+import { useAdContext } from '../model/ad-context'
+import { FooterAdSense } from './footer-ad-sense'
+
+const isDev = process.env.NODE_ENV === 'development'
+
+const FooterAdWrapper = ({ children }: { children: React.ReactNode }) => {
+  const { adState } = useAdContext()
+  // 광고게시 준비가 되었으나 게시할 광고가 없는경우
+  const isAdUnFilledStatus = !adState.isLoading && !adState.isAdFilled
+
+  return (
+    <footer
+      className={cn(
+        'mb-[6.25rem] max-h-[14.5rem] bg-slate-200 tab:max-h-[17.4375rem] pc:mb-0 pc:max-h-[9.5rem] pc:min-h-[9.5rem]',
+        isAdUnFilledStatus && 'mb-0',
+        isDev && 'mb-[6.25rem]',
+      )}
+    >
+      <div className='flex h-full flex-col items-center pc:container pc-lg:container pc:mx-auto pc:flex-row pc:justify-between pc:space-x-7 pc:px-[2.25rem] pc:py-2 pc-lg:space-x-0 pc-lg:px-[4.5rem]'>
+        {children}
+        <FooterAdSense />
+      </div>
+    </footer>
+  )
+}
+
+export { FooterAdWrapper }

--- a/src/shared/ui/footer-info-section.tsx
+++ b/src/shared/ui/footer-info-section.tsx
@@ -1,0 +1,73 @@
+import Image from 'next/image'
+import Link from 'next/link'
+
+import { CONTACT_INFO } from '../model/contact-info'
+
+const FooterInfoSection = () => {
+  return (
+    <div className='flex flex-col items-center gap-1 py-6 text-[0.625rem] pc:min-w-[24.0625rem] pc:items-start pc:py-0'>
+      {/* 고객센터 섹션 */}
+      <div className='flex gap-2 text-slate-600'>
+        <span className='text-xs font-semibold leading-[1.0425rem] tracking-[-0.015rem] tab:leading-[1.05rem] pc:text-[0.75rem] pc:leading-[1.035rem] pc:tracking-[-0.015rem]'>
+          <Link href='/order' className='hover:text-primary hover:underline'>
+            구매문의
+          </Link>
+        </span>
+        <a
+          href={`tel:${CONTACT_INFO.tel.value}`}
+          className='flex items-center gap-1 text-[0.6875rem] leading-[0.95563rem] tracking-[-0.01375rem] tab:leading-[0.9625rem] pc:text-[0.75rem] pc:leading-[1.035rem] pc:tracking-[-0.015rem]'
+        >
+          <div className='relative size-[0.83038rem]'>
+            <Image
+              className='object-cover'
+              src='/call.svg'
+              alt='call logo'
+              fill
+            />
+          </div>
+          <span>{CONTACT_INFO.tel.label}</span>
+        </a>
+        <a
+          href={`mailto:${CONTACT_INFO.email.value}`}
+          className='flex items-center gap-1 text-[0.6875rem] leading-[0.95563rem] tracking-[-0.01375rem] tab:leading-[0.9625rem]'
+        >
+          <div className='relative mb-[0.05rem] size-[0.83038rem]'>
+            <Image
+              className='object-cover'
+              src='/email.svg'
+              alt='email logo'
+              fill
+            />
+          </div>
+          <span>{CONTACT_INFO.email.label}</span>
+        </a>
+      </div>
+      {/* 저작권 정보 */}
+      <div className='text-center text-[0.625rem] font-normal leading-[0.86875rem] tracking-[-0.0125rem] text-slate-500 tab:leading-[0.875rem] pc:text-start pc:text-[0.75rem] pc:leading-[1.035rem] pc:tracking-[-0.015rem]'>
+        {/* 모바일 버전 */}
+        <p className='pc:hidden'>바른 한글은 부산대학교 인공지능연구실과</p>
+        <p className='pc:hidden'>(주)나라인포테크가 함께 만들고 있습니다.</p>
+        {/* PC 버전 */}
+        <p className='hidden pc:block'>
+          바른 한글은 부산대학교 인공지능연구실과 (주)나라인포테크가 함께 만들고
+          있습니다.
+        </p>
+        {/* 공통 텍스트 */}
+        <p>이 검사기는 개인이나 학생만 무료로 사용할 수 있습니다.</p>
+      </div>
+      {/* 카피라이트 */}
+      <div className='text-center text-[0.625rem] font-normal leading-[1.0625rem] tracking-[-0.0125rem] text-slate-500 tab:leading-[1.0625rem] pc:text-[0.75rem] pc:leading-[1.035rem] pc:tracking-[-0.015rem]'>
+        Copyrightⓒ2001 AI Lab & Narainfotech. All Rights Reserved
+      </div>
+      <a
+        href='https://rogue-toothpaste-2b9.notion.site/1ee8bd6bfd808016995ff0b71b2cb358'
+        target='_blank'
+        className='pt-1 text-xs text-primary hover:text-primary hover:underline pc:pt-2'
+      >
+        바른 한글 리뉴얼에 기여하신 분들
+      </a>
+    </div>
+  )
+}
+
+export { FooterInfoSection }

--- a/src/shared/ui/footer.tsx
+++ b/src/shared/ui/footer.tsx
@@ -1,88 +1,14 @@
-import Image from 'next/image'
-import Link from 'next/link'
-
-import { CONTACT_INFO } from '../model/contact-info'
-import { FooterAdSense } from './footer-ad-sense'
+import { AdProvider } from '../model/ad-context'
+import { FooterAdWrapper } from './footer-ad-wrapper'
+import { FooterInfoSection } from './footer-info-section'
 
 const Footer = () => {
   return (
-    <footer className='bg-slate-200 pt-6 pc:py-[1.875rem]'>
-      <div className='pc:container pc:mx-auto pc:px-[3.81rem]'>
-        <div className='flex flex-col items-center justify-center tab:min-h-[90px] pc:flex-row pc:justify-between'>
-          <div className='flex flex-col items-center gap-1 pb-4 text-[0.625rem] tab:pb-[4.8262rem] pc:items-start pc:pb-0'>
-            {/* 고객센터 섹션 */}
-            <div className='flex gap-2 text-slate-600'>
-              <span className='text-xs font-semibold leading-[1.0425rem] tracking-[-0.015rem] tab:leading-[1.05rem] pc:text-[0.75rem] pc:leading-[1.035rem] pc:tracking-[-0.015rem]'>
-                <Link
-                  href='/order'
-                  className='hover:text-primary hover:underline'
-                >
-                  구매문의
-                </Link>
-              </span>
-              <a
-                href={`tel:${CONTACT_INFO.tel.value}`}
-                className='flex items-center gap-1 text-[0.6875rem] leading-[0.95563rem] tracking-[-0.01375rem] tab:leading-[0.9625rem] pc:text-[0.75rem] pc:leading-[1.035rem] pc:tracking-[-0.015rem]'
-              >
-                <div className='relative size-[0.83038rem]'>
-                  <Image
-                    className='object-cover'
-                    src='/call.svg'
-                    alt='call logo'
-                    fill
-                  />
-                </div>
-                <span>{CONTACT_INFO.tel.label}</span>
-              </a>
-              <a
-                href={`mailto:${CONTACT_INFO.email.value}`}
-                className='flex items-center gap-1 text-[0.6875rem] leading-[0.95563rem] tracking-[-0.01375rem] tab:leading-[0.9625rem]'
-              >
-                <div className='relative mb-[0.05rem] size-[0.83038rem]'>
-                  <Image
-                    className='object-cover'
-                    src='/email.svg'
-                    alt='email logo'
-                    fill
-                  />
-                </div>
-                <span>{CONTACT_INFO.email.label}</span>
-              </a>
-            </div>
-            {/* 저작권 정보 */}
-            <div className='text-center text-[0.625rem] font-normal leading-[0.86875rem] tracking-[-0.0125rem] text-slate-500 tab:leading-[0.875rem] pc:text-start pc:text-[0.75rem] pc:leading-[1.035rem] pc:tracking-[-0.015rem]'>
-              {/* 모바일 버전 */}
-              <p className='pc:hidden'>
-                바른 한글은 부산대학교 인공지능연구실과
-              </p>
-              <p className='pc:hidden'>
-                (주)나라인포테크가 함께 만들고 있습니다.
-              </p>
-              {/* PC 버전 */}
-              <p className='hidden pc:block'>
-                바른 한글은 부산대학교 인공지능연구실과 (주)나라인포테크가 함께
-                만들고 있습니다.
-              </p>
-              {/* 공통 텍스트 */}
-              <p>이 검사기는 개인이나 학생만 무료로 사용할 수 있습니다.</p>
-            </div>
-            {/* 카피라이트 */}
-            <div className='text-center text-[0.625rem] font-normal leading-[1.0625rem] tracking-[-0.0125rem] text-slate-500 tab:leading-[1.0625rem] pc:text-[0.75rem] pc:leading-[1.035rem] pc:tracking-[-0.015rem]'>
-              Copyrightⓒ2001 AI Lab & Narainfotech. All Rights Reserved
-            </div>
-            <a
-              href='https://rogue-toothpaste-2b9.notion.site/1ee8bd6bfd808016995ff0b71b2cb358'
-              target='_blank'
-              className='pt-1 text-xs text-primary hover:text-primary hover:underline pc:pt-2'
-            >
-              바른 한글 리뉴얼에 기여하신 분들
-            </a>
-          </div>
-          {/* 광고 영역 */}
-          <FooterAdSense />
-        </div>
-      </div>
-    </footer>
+    <AdProvider>
+      <FooterAdWrapper>
+        <FooterInfoSection />
+      </FooterAdWrapper>
+    </AdProvider>
   )
 }
 

--- a/src/shared/ui/header.tsx
+++ b/src/shared/ui/header.tsx
@@ -6,7 +6,7 @@ import { Popover, PopoverContent, PopoverTrigger } from './popover'
 const Header = () => {
   return (
     <div className='flex items-center justify-center bg-white'>
-      <header className='flex flex-1 items-center justify-between px-6 py-4 pc:container tab:px-[3.75rem] tab:py-5 pc:p-[2rem_3.75rem]'>
+      <header className='flex flex-1 items-center justify-between px-6 py-4 pc:container pc-lg:container tab:px-[3.75rem] tab:py-5 pc:p-[1rem_1.875rem] pc-lg:p-[2rem_3.75rem]'>
         <div className='flex items-center gap-5'>
           <Link href='/'>
             <h1 className='text-xl font-bold tab:text-2xl'>
@@ -29,7 +29,7 @@ const Header = () => {
             문의하기
           </Link>
           <Link
-            href='https://nara-speller.co.kr/speller/'
+            href='./old_speller/'
             className='hidden rounded-lg border border-[#B8B8BE] p-3 font-semibold !leading-none text-slate-500 hover:bg-accent tab:inline-flex tab:text-xl pc:text-base'
           >
             이전 버전 사용하기
@@ -67,7 +67,7 @@ const Header = () => {
               </li>
               <li className='group'>
                 <Link
-                  href='https://nara-speller.co.kr/speller/'
+                  href='./old_speller/'
                   className={`${classes.popoverButton} border-none`}
                 >
                   <i

--- a/src/shared/ui/main-ad-sense.tsx
+++ b/src/shared/ui/main-ad-sense.tsx
@@ -8,11 +8,19 @@ import { cn } from '../lib/tailwind-merge'
 import { useClient } from '../lib/use-client'
 import { useBreakpoint } from '../lib/use-break-point'
 import { useAdRetryKey } from '../lib/use-ad-retry-key'
+import { AdProvider, useAdContext } from '../model/ad-context'
+import { Skeleton } from './skeleton'
 
 const MAX_RETRIES = 3
 const isDev = process.env.NODE_ENV === 'development'
 
-const MainAdSense = () => {
+const MainAdSlot = () => {
+  const {
+    adState: { isAdFilled, isDoneAd, isLoading },
+    resetAdState,
+    readyAdState,
+    failAdState,
+  } = useAdContext()
   const pathname = usePathname()
   const isClient = useClient()
   const breakpoint = useBreakpoint()
@@ -20,9 +28,19 @@ const MainAdSense = () => {
     `main-ad-${pathname}-${breakpoint}`,
     MAX_RETRIES,
   )
+  // 광고 로딩은 완료되었으나, 표시할 광고가 없는 상태
+  const isAdUnFilledStatus = !isAdFilled && isDoneAd
+  const shouldRender =
+    isClient && ['desktop', 'desktop-small'].includes(breakpoint)
 
   useEffect(() => {
     reset()
+    resetAdState()
+
+    return () => {
+      reset()
+      resetAdState()
+    }
   }, [pathname, breakpoint])
 
   const handleUnFilled = () => {
@@ -31,32 +49,57 @@ const MainAdSense = () => {
       console.warn(`🔁 광고 재시도: ${retryCount + 1}/${MAX_RETRIES}`)
     } else {
       console.warn('🛑 광고 재시도 최대 도달 – fallback 고려')
+      failAdState()
     }
   }
 
   const handleFilled = () => {
     console.log('✅ 메인 광고 성공적으로 로드됨')
+    readyAdState()
   }
 
-  if (!isClient || breakpoint !== 'desktop') return null
+  if (!shouldRender) return null
 
   if (isDev) {
     return <div className={cn(AdStyle, 'bg-slate-300')} />
   }
 
   return (
-    <GoogleAdSense
-      key={adKey}
-      className={AdStyle}
-      data-ad-slot='9725653724'
-      data-full-width-responsive='true'
-      onAdFilled={handleFilled}
-      onAdUnfilled={handleUnFilled}
-    />
+    <div className={cn('relative', isAdUnFilledStatus && 'hidden')}>
+      {/* 광고 로딩 UI */}
+      {isLoading ? (
+        <Skeleton
+          className={cn(AdStyle, 'absolute inset-0 m-auto bg-slate-300')}
+        />
+      ) : null}
+      <div
+        className={cn(
+          'transition-opacity',
+          isLoading ? 'pointer-events-none opacity-0' : 'opacity-100',
+        )}
+      >
+        <GoogleAdSense
+          key={adKey}
+          className={AdStyle}
+          data-ad-slot='9725653724'
+          data-full-width-responsive='true'
+          onAdFilled={handleFilled}
+          onAdUnfilled={handleUnFilled}
+        />
+      </div>
+    </div>
   )
 }
 
 const AdStyle =
-  'my-24 h-[37.5rem] w-40 place-content-center overflow-hidden rounded-sm pc:ml-5 pc:block'
+  'my-24 h-[37.5rem] w-40 self-center overflow-hidden rounded-sm pc:ml-5 pc:block'
+
+const MainAdSense = () => {
+  return (
+    <AdProvider>
+      <MainAdSlot />
+    </AdProvider>
+  )
+}
 
 export { MainAdSense }

--- a/src/shared/ui/textarea.tsx
+++ b/src/shared/ui/textarea.tsx
@@ -27,9 +27,9 @@ const Textarea = forwardRef<TextareaHandle, TextareaProps>(
 
       if (!textarea) return
 
-      if (textarea.value.length <= 0) {
-        textarea.style.height = '100%'
-      } else {
+      textarea.style.height = '100%'
+
+      if (textarea.value.length > 0) {
         textarea.style.height = `${textarea.scrollHeight}px`
       }
     }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,9 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 import type { Config } from 'tailwindcss'
+
+export const TABLET = 726
+export const DESKTOP = 1024
+export const LARGE_DESKTOP = 1377
 
 export default {
   darkMode: ['class'],
@@ -9,8 +14,9 @@ export default {
   ],
   theme: {
     screens: {
-      tab: '726px',
-      pc: '1377px',
+      tab: `${TABLET}px`,
+      pc: `${DESKTOP}px`,
+      ['pc-lg']: `${LARGE_DESKTOP}px`,
     },
     colors: {
       transparent: 'transparent',
@@ -109,6 +115,8 @@ export default {
       },
     },
   },
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  plugins: [require('tailwindcss-animate')],
+  plugins: [
+    require('tailwindcss-animate'),
+    require('@tailwindcss/container-queries'),
+  ],
 } satisfies Config


### PR DESCRIPTION
#### 작업내용

**광고 영역 및 UI 개선**
- 1024px 이상 해상도에 대해, 기존 태블릿 UI 대신 작은 데스크탑 전용 UI를 추가 및 수정했습니다.
- 광고가 data-ad-status="unfilled" 상태일 경우, 빈 광고 영역을 제거하고 주변 레이아웃과 자연스럽게 통합되도록 개선했습니다.
- 데스크탑에서는 광고가 로딩 중일 때 사용자에게 스켈레톤 UI를 제공하여 시각적 안정성과 UX를 높였습니다.
- 모바일에서는 스켈레톤 UI 적용 시 깜빡임 현상이 발생하여, 스켈레톤을 모바일에선 비활성화했습니다.
- 또한 모바일의 화면 높이 제약을 고려하여, 광고가 unfilled 상태에 도달하면 광고 영역 자체를 제거하여 시야 확보를 개선했습니다.
- 기획 변경에 따라, 모바일/태블릿 광고는 고정된 높이와 위치로 표시되도록 수정했습니다.

**UI/레이아웃 개선**
- 화면 높이에 따라 최소 여백을 유지하면서도 동적으로 확장 가능하도록 개선하여, 전반적인 개방감을 높였습니다.
- 디자이너 시안과 일치하지 않았던 일부 UI 요소를 수정하였습니다.
- '이전 버전 사용하기' 링크를 기획에 맞게 수정하였습니다.

**버그 수정 및 기술 개선**
-원문 입력 시 높이 갱신이 되지 않던 버그를 수정했습니다.
-hook.js:608 AdSense head tag doesn't support data-nscript attribute 워닝이 발생하던 문제를 해결하기 위해, AdSense 스크립트 로드 방식을 수정했습니다.

### Ref
Closes #224  
Closes #223  
Closes #215  
Closes #214