### PR TITLE
[#213] GA4 1차 이벤트 측정 기능 도입

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,19 +10,17 @@ const nextConfig: NextConfig = {
     })
     return config
   },
-  experimental: {
-    turbo:
-      process.env.NODE_ENV === 'development'
-        ? {
-            rules: {
-              '*.svg': {
-                loaders: ['@svgr/webpack'],
-                as: '*.js',
-              },
+  turbopack:
+    process.env.NODE_ENV === 'development'
+      ? {
+          rules: {
+            '*.svg': {
+              loaders: ['@svgr/webpack'],
+              as: '*.js',
             },
-          }
-        : {},
-  },
+          },
+        }
+      : {},
 }
 
 export default nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@frontend-opensource/use-react-hooks": "^1.1.4",
+        "@next/third-parties": "^15.3.2",
         "@radix-ui/react-checkbox": "^1.2.3",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-label": "^2.1.1",
@@ -22,7 +23,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "lucide-react": "^0.456.0",
-        "next": "^15.2.4",
+        "next": "^15.3.2",
         "overlayscrollbars": "^2.10.1",
         "overlayscrollbars-react": "^0.5.6",
         "react": "^19.0.0",
@@ -1864,9 +1865,10 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
-      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
+      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -2177,6 +2179,22 @@
       "cpu": [
         "arm64"
       ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.1.0.tgz",
+      "integrity": "sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -2538,9 +2556,10 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.4.tgz",
-      "integrity": "sha512-+SFtMgoiYP3WoSswuNmxJOCwi06TdWE733D+WPjpXIe4LXGULwEaofiiAy6kbS0+XjM5xF5n3lKuBwN2SnqD9g=="
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.2.tgz",
+      "integrity": "sha512-xURk++7P7qR9JG1jJtLzPzf0qEvqCN0A/T3DXf8IPMKo9/6FfjxtEffRJIIew/bIL4T3C2jLLqBor8B/zVlx6g==",
+      "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "15.1.7",
@@ -2551,12 +2570,13 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.4.tgz",
-      "integrity": "sha512-1AnMfs655ipJEDC/FHkSr0r3lXBgpqKo4K1kiwfUf3iE68rDFXZ1TtHdMvf7D0hMItgDZ7Vuq3JgNMbt/+3bYw==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.2.tgz",
+      "integrity": "sha512-2DR6kY/OGcokbnCsjHpNeQblqCZ85/1j6njYSkzRdpLn5At7OkSdmk7WyAmB9G0k25+VgqVZ/u356OSoQZ3z0g==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2566,12 +2586,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.4.tgz",
-      "integrity": "sha512-3qK2zb5EwCwxnO2HeO+TRqCubeI/NgCe+kL5dTJlPldV/uwCnUgC7VbEzgmxbfrkbjehL4H9BPztWOEtsoMwew==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.2.tgz",
+      "integrity": "sha512-ro/fdqaZWL6k1S/5CLv1I0DaZfDVJkWNaUU3un8Lg6m0YENWlDulmIWzV96Iou2wEYyEsZq51mwV8+XQXqMp3w==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2581,12 +2602,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.4.tgz",
-      "integrity": "sha512-HFN6GKUcrTWvem8AZN7tT95zPb0GUGv9v0d0iyuTb303vbXkkbHDp/DxufB04jNVD+IN9yHy7y/6Mqq0h0YVaQ==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.2.tgz",
+      "integrity": "sha512-covwwtZYhlbRWK2HlYX9835qXum4xYZ3E2Mra1mdQ+0ICGoMiw1+nVAn4d9Bo7R3JqSmK1grMq/va+0cdh7bJA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2596,12 +2618,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.4.tgz",
-      "integrity": "sha512-Oioa0SORWLwi35/kVB8aCk5Uq+5/ZIumMK1kJV+jSdazFm2NzPDztsefzdmzzpx5oGCJ6FkUC7vkaUseNTStNA==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.2.tgz",
+      "integrity": "sha512-KQkMEillvlW5Qk5mtGA/3Yz0/tzpNlSw6/3/ttsV1lNtMuOHcGii3zVeXZyi4EJmmLDKYcTcByV2wVsOhDt/zg==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2611,12 +2634,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.4.tgz",
-      "integrity": "sha512-yb5WTRaHdkgOqFOZiu6rHV1fAEK0flVpaIN2HB6kxHVSy/dIajWbThS7qON3W9/SNOH2JWkVCyulgGYekMePuw==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.2.tgz",
+      "integrity": "sha512-uRBo6THWei0chz+Y5j37qzx+BtoDRFIkDzZjlpCItBRXyMPIg079eIkOCl3aqr2tkxL4HFyJ4GHDes7W8HuAUg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2626,12 +2650,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.4.tgz",
-      "integrity": "sha512-Dcdv/ix6srhkM25fgXiyOieFUkz+fOYkHlydWCtB0xMST6X9XYI3yPDKBZt1xuhOytONsIFJFB08xXYsxUwJLw==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.2.tgz",
+      "integrity": "sha512-+uxFlPuCNx/T9PdMClOqeE8USKzj8tVz37KflT3Kdbx/LOlZBRI2yxuIcmx1mPNK8DwSOMNCr4ureSet7eyC0w==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2641,12 +2666,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.4.tgz",
-      "integrity": "sha512-dW0i7eukvDxtIhCYkMrZNQfNicPDExt2jPb9AZPpL7cfyUo7QSNl1DjsHjmmKp6qNAqUESyT8YFl/Aw91cNJJg==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.2.tgz",
+      "integrity": "sha512-LLTKmaI5cfD8dVzh5Vt7+OMo+AIOClEdIU/TSKbXXT2iScUTSxOGoBhfuv+FU8R9MLmrkIL1e2fBMkEEjYAtPQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2656,18 +2682,32 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.4.tgz",
-      "integrity": "sha512-SbnWkJmkS7Xl3kre8SdMF6F/XDh1DTFEhp0jRTj/uB8iPKoU2bb2NDfcu+iifv1+mxQEd1g2vvSxcZbXSKyWiQ==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.2.tgz",
+      "integrity": "sha512-aW5B8wOPioJ4mBdMDXkt5f3j8pUr9W8AnlX0Df35uRWNT1Y6RIybxjnSUe+PhM+M1bwgyY8PHLmXZC6zT1o5tA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.3.2.tgz",
+      "integrity": "sha512-zE9xYkMKZ6gLbkP6lWt60yaeKB5r0A4eZhFKAhgik/eO+zzZPFkTy5K7+0ykgfB6MTkcend3BaDXZhz9KnDjYw==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7938,11 +7978,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.2.4.tgz",
-      "integrity": "sha512-VwL+LAaPSxEkd3lU2xWbgEOtrM8oedmyhBqaVNmgKB+GvZlCy9rgaEc+y2on0wv+l0oSFqLtYD6dcC1eAedUaQ==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.3.2.tgz",
+      "integrity": "sha512-CA3BatMyHkxZ48sgOCLdVHjFU36N7TF1HhqAHLFOkV6buwZnvMI84Cug8xD56B9mCuKrqXnLn94417GrZ/jjCQ==",
+      "license": "MIT",
       "dependencies": {
-        "@next/env": "15.2.4",
+        "@next/env": "15.3.2",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",
@@ -7957,15 +7998,15 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.2.4",
-        "@next/swc-darwin-x64": "15.2.4",
-        "@next/swc-linux-arm64-gnu": "15.2.4",
-        "@next/swc-linux-arm64-musl": "15.2.4",
-        "@next/swc-linux-x64-gnu": "15.2.4",
-        "@next/swc-linux-x64-musl": "15.2.4",
-        "@next/swc-win32-arm64-msvc": "15.2.4",
-        "@next/swc-win32-x64-msvc": "15.2.4",
-        "sharp": "^0.33.5"
+        "@next/swc-darwin-arm64": "15.3.2",
+        "@next/swc-darwin-x64": "15.3.2",
+        "@next/swc-linux-arm64-gnu": "15.3.2",
+        "@next/swc-linux-arm64-musl": "15.3.2",
+        "@next/swc-linux-x64-gnu": "15.3.2",
+        "@next/swc-linux-x64-musl": "15.3.2",
+        "@next/swc-win32-arm64-msvc": "15.3.2",
+        "@next/swc-win32-x64-msvc": "15.3.2",
+        "sharp": "^0.34.1"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -7988,6 +8029,367 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.1.tgz",
+      "integrity": "sha512-pn44xgBtgpEbZsu+lWf2KNb6OAf70X68k+yk69Ic2Xz11zHR/w24/U49XT7AeRwJ0Px+mhALhU5LPci1Aymk7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.1.0"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.1.tgz",
+      "integrity": "sha512-VfuYgG2r8BpYiOUN+BfYeFo69nP/MIwAtSJ7/Zpxc5QF3KS22z8Pvg3FkrSFJBPNQ7mmcUcYQFBmEQp7eu1F8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.1.0"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.1.0.tgz",
+      "integrity": "sha512-Xzc2ToEmHN+hfvsl9wja0RlnXEgpKNmftriQp6XzY/RaSfwD9th+MSh0WQKzUreLKKINb3afirxW7A0fz2YWuQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.1.0.tgz",
+      "integrity": "sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.1.0.tgz",
+      "integrity": "sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.1.0.tgz",
+      "integrity": "sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.1.0.tgz",
+      "integrity": "sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.1.0.tgz",
+      "integrity": "sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.1.0.tgz",
+      "integrity": "sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.1.tgz",
+      "integrity": "sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.1.0"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.1.tgz",
+      "integrity": "sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.1.0"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.1.tgz",
+      "integrity": "sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.1.0"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.1.tgz",
+      "integrity": "sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.1.0"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.1.tgz",
+      "integrity": "sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.1.0"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.1.tgz",
+      "integrity": "sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.1.0"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-wasm32": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.1.tgz",
+      "integrity": "sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.1.tgz",
+      "integrity": "sha512-WKf/NAZITnonBf3U1LfdjoMgNO5JYRSlhovhRhMxXVdvWYveM4kM3L8m35onYIdh75cOMCo1BexgVQcCDzyoWw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.1.tgz",
+      "integrity": "sha512-hw1iIAHpNE8q3uMIRCgGOeDoz9KtFNarFLQclLxr/LK1VBkj8nby18RjFvr6aP7USRYAjTZW6yisnBWMX571Tw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -8014,6 +8416,47 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/next/node_modules/sharp": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.1.tgz",
+      "integrity": "sha512-1j0w61+eVxu7DawFJtnfYcvSv6qPFvfTaqzTQ2BLknVhHTwGS8sc63ZBF4rzkWMBVKybo4S5OBtDdZahh2A1xg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.1",
+        "@img/sharp-darwin-x64": "0.34.1",
+        "@img/sharp-libvips-darwin-arm64": "1.1.0",
+        "@img/sharp-libvips-darwin-x64": "1.1.0",
+        "@img/sharp-libvips-linux-arm": "1.1.0",
+        "@img/sharp-libvips-linux-arm64": "1.1.0",
+        "@img/sharp-libvips-linux-ppc64": "1.1.0",
+        "@img/sharp-libvips-linux-s390x": "1.1.0",
+        "@img/sharp-libvips-linux-x64": "1.1.0",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.1.0",
+        "@img/sharp-libvips-linuxmusl-x64": "1.1.0",
+        "@img/sharp-linux-arm": "0.34.1",
+        "@img/sharp-linux-arm64": "0.34.1",
+        "@img/sharp-linux-s390x": "0.34.1",
+        "@img/sharp-linux-x64": "0.34.1",
+        "@img/sharp-linuxmusl-arm64": "0.34.1",
+        "@img/sharp-linuxmusl-x64": "0.34.1",
+        "@img/sharp-wasm32": "0.34.1",
+        "@img/sharp-win32-ia32": "0.34.1",
+        "@img/sharp-win32-x64": "0.34.1"
       }
     },
     "node_modules/no-case": {
@@ -9939,6 +10382,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@frontend-opensource/use-react-hooks": "^1.1.4",
+    "@next/third-parties": "^15.3.2",
     "@radix-ui/react-checkbox": "^1.2.3",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-label": "^2.1.1",
@@ -27,7 +28,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.456.0",
-    "next": "^15.2.4",
+    "next": "^15.3.2",
     "overlayscrollbars": "^2.10.1",
     "overlayscrollbars-react": "^0.5.6",
     "react": "^19.0.0",

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -5,6 +5,7 @@ import localFont from 'next/font/local'
 
 import { Toaster } from '@/shared/ui/toaster'
 import { GoogleAdsenseScript } from '@/shared/lib/google-ad-sense-script'
+import { GoogleAnalyticsScript } from '@/shared/lib/google-analytics-script'
 
 const pretendard = localFont({
   src: './font/pretendard-variable.woff2',
@@ -27,6 +28,7 @@ const App = ({
         {children}
         <Toaster />
       </body>
+      <GoogleAnalyticsScript />
     </html>
   )
 }

--- a/src/entities/report/ui/report-form-content.tsx
+++ b/src/entities/report/ui/report-form-content.tsx
@@ -2,12 +2,18 @@ import { useSendReport } from '@/entities/report/model/use-send-report'
 import { BasicTextarea } from '@/shared/ui/basic-textarea'
 import { Button } from '@/shared/ui/button'
 import { toast } from '@/shared/lib/use-toast'
+import { sendCorrectionFeedbackSubmittedEvent } from '@/shared/lib/send-ga-event'
+import { CorrectedErrorType } from '@/shared/lib/analytics-event-types'
 
 interface ReportFormContentProps {
   handleClose: () => void
+  errorType: CorrectedErrorType
 }
 
-export const ReportFormContent = ({ handleClose }: ReportFormContentProps) => {
+export const ReportFormContent = ({
+  handleClose,
+  errorType,
+}: ReportFormContentProps) => {
   const { comment, handleChange, handleSubmit } = useSendReport({
     handleClose: () => {
       toast({
@@ -31,7 +37,14 @@ export const ReportFormContent = ({ handleClose }: ReportFormContentProps) => {
       <Button
         disabled={!comment}
         className='h-[2.65rem] py-[0.88rem] text-[0.95rem] tab:h-[3.125rem] tab:text-lg pc:mt-[0.75rem] pc:h-[2.5rem] pc:rounded-[0.42rem] pc:py-[0.7rem] pc:text-base'
-        onClick={handleSubmit}
+        onClick={() => {
+          handleSubmit()
+          sendCorrectionFeedbackSubmittedEvent({
+            sectionType: 'correction_item',
+            textLength: comment.length,
+            correctedErrorType: errorType,
+          })
+        }}
       >
         제출하기
       </Button>

--- a/src/entities/report/ui/report-form.tsx
+++ b/src/entities/report/ui/report-form.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+import React, { ReactNode, useState } from 'react'
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
+
 import { Button } from '@/shared/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/shared/ui/popover'
 import {
@@ -9,16 +12,16 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/shared/ui/dialog'
-import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
-import React, { ReactNode, useState } from 'react'
 import { ReportFormContent } from './report-form-content'
 import SendIcon from '@/shared/ui/icon/icon-send-black.svg'
+import { CorrectedErrorType } from '@/shared/lib/analytics-event-types'
 
 interface ReportFormProps {
   children: ReactNode
+  errorType: CorrectedErrorType
 }
 
-export const ReportForm = ({ children }: ReportFormProps) => {
+export const ReportForm = ({ children, errorType }: ReportFormProps) => {
   const [isPopoverOpen, setPopoverOpen] = useState(false)
   const [isDialogOpen, setDialogOpen] = useState(false)
 
@@ -46,7 +49,10 @@ export const ReportForm = ({ children }: ReportFormProps) => {
                 onClick={handlePopoverClose}
               ></Button>
             </div>
-            <ReportFormContent handleClose={handlePopoverClose} />
+            <ReportFormContent
+              handleClose={handlePopoverClose}
+              errorType={errorType}
+            />
           </div>
         </PopoverContent>
       </Popover>
@@ -62,7 +68,10 @@ export const ReportForm = ({ children }: ReportFormProps) => {
             </DialogTitle>
             <ReportFormTitle />
           </DialogHeader>
-          <ReportFormContent handleClose={handleDialogClose} />
+          <ReportFormContent
+            handleClose={handleDialogClose}
+            errorType={errorType}
+          />
         </DialogContent>
       </Dialog>
     </>

--- a/src/entities/speller/index.ts
+++ b/src/entities/speller/index.ts
@@ -1,6 +1,10 @@
 export { SpellerApi } from './api/speller-service'
 export { getTextMethodColor, getBgMethodColor } from './lib/get-method-color'
 export { parseCandidateWords } from './lib/parse-candidate-words'
+export {
+  useSetStrictCheckQuery,
+  useStrictCheckQuery,
+} from './lib/use-strict-check-query'
 export type {
   UserReplacePayload,
   NotChangePayload,

--- a/src/entities/speller/lib/get-corrected-error-type.ts
+++ b/src/entities/speller/lib/get-corrected-error-type.ts
@@ -1,0 +1,12 @@
+import { CorrectedErrorType } from '@/shared/lib/analytics-event-types'
+import { CorrectMethod } from '../model/speller-schema'
+
+const correctMethodToErrorTypeMap: Record<CorrectMethod, CorrectedErrorType> = {
+  [CorrectMethod.띄어쓰기]: 'spacing',
+  [CorrectMethod.오탈자]: 'typo',
+  [CorrectMethod.문맥]: 'context',
+}
+
+export const getCorrectedErrorType = (method: number): CorrectedErrorType => {
+  return correctMethodToErrorTypeMap[method as CorrectMethod] ?? 'context'
+}

--- a/src/entities/speller/lib/use-strict-check-query.ts
+++ b/src/entities/speller/lib/use-strict-check-query.ts
@@ -1,0 +1,35 @@
+'use client'
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+
+const QUERY_NAME = 'isStrictCheck' as const
+
+const useStrictCheckQuery = () => {
+  const searchParams = useSearchParams()
+
+  if (!searchParams) return false
+
+  return searchParams.get(QUERY_NAME) === 'true'
+}
+
+const useSetStrictCheckQuery = () => {
+  const searchParams = useSearchParams()
+  const pathname = usePathname()
+  const { replace } = useRouter()
+
+  return (checked: boolean) => {
+    if (!searchParams) return
+
+    const params = new URLSearchParams(searchParams.toString())
+
+    if (checked) {
+      params.set(QUERY_NAME, 'true')
+    } else {
+      params.delete(QUERY_NAME)
+    }
+
+    replace(`${pathname}?${params.toString()}`, { scroll: false })
+  }
+}
+
+export { useStrictCheckQuery, useSetStrictCheckQuery }

--- a/src/entities/speller/ui/speller-setting.tsx
+++ b/src/entities/speller/ui/speller-setting.tsx
@@ -1,44 +1,20 @@
 'use client'
 
 import React, { memo } from 'react'
-import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 
 import { Label } from '@/shared/ui/label'
 import { Switch } from '@/shared/ui/switch'
-
-const QUERY = 'isStrictCheck'
+import {
+  useSetStrictCheckQuery,
+  useStrictCheckQuery,
+} from '../lib/use-strict-check-query'
 
 const SpellerSetting = memo(() => {
-  const searchParams = useSearchParams()
-  const pathname = usePathname()
-  const { replace } = useRouter()
-
-  const updateStrictCheckQueryParams = (checked: boolean) => {
-    if (!searchParams) return
-
-    const params = new URLSearchParams(searchParams.toString())
-
-    if (checked) {
-      params.set(QUERY, 'true')
-    } else {
-      params.delete(QUERY)
-    }
-
-    return params.toString()
-  }
+  const isStrict = useStrictCheckQuery()
+  const setStrict = useSetStrictCheckQuery()
 
   const handleCheckedChange = (checked: boolean) => {
-    const newParams = updateStrictCheckQueryParams(checked)
-
-    if (newParams !== undefined) {
-      replace(`${pathname}?${newParams}`, { scroll: false })
-    }
-  }
-
-  const isStrictCheckEnabled = () => {
-    if (!searchParams) return false
-
-    return searchParams.get(QUERY) === 'true'
+    setStrict(checked)
   }
 
   return (
@@ -55,7 +31,7 @@ const SpellerSetting = memo(() => {
         id='airplane-mode'
         name='isStrictCheck'
         onCheckedChange={handleCheckedChange}
-        checked={isStrictCheckEnabled()}
+        checked={isStrict}
       />
     </div>
   )

--- a/src/pages/results/ui/custom-text-editor-content.tsx
+++ b/src/pages/results/ui/custom-text-editor-content.tsx
@@ -4,6 +4,8 @@ import { Button } from '@/shared/ui/button'
 import { Input } from '@/shared/ui/input'
 import { useUserReplace } from '../model/use-user-replace'
 import { BulletBadge } from '../ui/bullet-badge'
+import { sendManualCorrectionSubmittedEvent } from '@/shared/lib/send-ga-event'
+import { getCorrectedErrorType } from '@/entities/speller/lib/get-corrected-error-type'
 
 interface CustomTextEditorContent {
   handleClose: () => void
@@ -43,7 +45,14 @@ export const CustomTextEditorContent = ({
       <Button
         disabled={!value}
         className='h-[2.65rem] py-[0.88rem] text-[0.95rem] tab:h-[3.125rem] tab:text-[1.125rem] pc:h-[2.5rem] pc:rounded-[0.31rem] pc:py-[0.84rem] pc:text-base'
-        onClick={handleEdit}
+        onClick={() => {
+          handleEdit()
+          sendManualCorrectionSubmittedEvent({
+            sectionType: 'correction_item',
+            correctedErrorType: getCorrectedErrorType(correctMethod),
+            textLength: value.length,
+          })
+        }}
       >
         수정하기
       </Button>

--- a/src/pages/results/ui/error-info-section.tsx
+++ b/src/pages/results/ui/error-info-section.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { XIcon } from 'lucide-react'
+
 import {
   useSpeller,
   type ErrorInfo,
@@ -10,13 +12,13 @@ import { Button } from '@/shared/ui/button'
 import { cn } from '@/shared/lib/tailwind-merge'
 import EditIcon from '@/shared/ui/icon/icon-edit.svg'
 import SendIcon from '@/shared/ui/icon/icon-send-gray.svg'
-
 import { HelpSection } from './help-section'
 import { CustomTextEditor } from './custom-text-editor'
 import { logClickReplaceAction } from '../api/log-click-replace-action'
 import { extractContext } from '../lib/extractContext'
 import { BulletBadge } from '../ui/bullet-badge'
-import { XIcon } from 'lucide-react'
+import { sendCorrectionWordClickedEvent } from '@/shared/lib/send-ga-event'
+import { getCorrectedErrorType } from '@/entities/speller/lib/get-corrected-error-type'
 
 interface ErrorInfoSectionProps<T>
   extends React.RefAttributes<T>,
@@ -45,6 +47,11 @@ const ErrorInfoSection = <T extends HTMLDivElement>({
 
   const handleRevert = () => {
     handleUpdateCorrectInfo({ ...errorInfo, crtStr: orgStr })
+    sendCorrectionWordClickedEvent({
+      sectionType: 'correction_item',
+      wordTextType: 'suggested',
+      correctedErrorType: getCorrectedErrorType(correctMethod),
+    })
   }
 
   return (

--- a/src/pages/results/ui/error-info-section.tsx
+++ b/src/pages/results/ui/error-info-section.tsx
@@ -127,7 +127,7 @@ const ErrorInfoSection = <T extends HTMLDivElement>({
           도움말
         </dt>
         <dd>
-          <HelpSection help={help} />
+          <HelpSection help={help} correctMethod={correctMethod} />
         </dd>
       </dl>
     </div>

--- a/src/pages/results/ui/help-section.tsx
+++ b/src/pages/results/ui/help-section.tsx
@@ -8,16 +8,23 @@ import { Button } from '@/shared/ui/button'
 import { cn } from '@/shared/lib/tailwind-merge'
 import ArrowBottomIcon from '@/shared/ui/icon/icon-arrow-bottom.svg'
 import { DESKTOP, TABLET } from '../../../../tailwind.config'
+import { getCorrectedErrorType } from '@/entities/speller/lib/get-corrected-error-type'
+import {
+  sendErrorDetailClosedEvent,
+  sendErrorDetailOpenedEvent,
+} from '@/shared/lib/send-ga-event'
 
 interface HelpSectionProps {
   help: string
+  correctMethod: number
 }
 
-const HelpSection = ({ help }: HelpSectionProps) => {
+const HelpSection = ({ help, correctMethod }: HelpSectionProps) => {
   const [isExpanded, setIsExpanded] = useState<boolean>(false)
   const [showButton, setShowButton] = useState<boolean>(false)
   const contentRef = useRef<HTMLParagraphElement>(null)
   const { width } = useWindowSize()
+  const correctedErrorType = getCorrectedErrorType(correctMethod)
 
   const checkContentHeight = useDebounce(() => {
     if (!contentRef.current) return
@@ -58,7 +65,17 @@ const HelpSection = ({ help }: HelpSectionProps) => {
           isExpanded && 'text-slate-400',
           showButton && 'visible',
         )}
-        onClick={() => setIsExpanded(!isExpanded)}
+        onClick={() => {
+          const next = !isExpanded
+
+          if (next) {
+            sendErrorDetailOpenedEvent({ correctedErrorType })
+          } else {
+            sendErrorDetailClosedEvent({ correctedErrorType })
+          }
+
+          setIsExpanded(next)
+        }}
       >
         {isExpanded ? '접기' : '자세히 보기'}
         <ArrowBottomIcon

--- a/src/pages/results/ui/spelling-correction-text.tsx
+++ b/src/pages/results/ui/spelling-correction-text.tsx
@@ -1,4 +1,5 @@
 import { ClipboardEvent, Fragment, memo, ReactNode, useMemo } from 'react'
+import { cn } from '@/shared/lib/tailwind-merge'
 
 import {
   useSpeller,
@@ -6,7 +7,8 @@ import {
   getTextMethodColor,
   CorrectInfo,
 } from '@/entities/speller'
-import { cn } from '@/shared/lib/tailwind-merge'
+import { sendCorrectionWordClickedEvent } from '@/shared/lib/send-ga-event'
+import { getCorrectedErrorType } from '@/entities/speller/lib/get-corrected-error-type'
 
 const SpellingCorrectionText = memo(() => {
   const { correctRefs, scrollSection } = useSpellerRefs()
@@ -56,6 +58,13 @@ const SpellingCorrectionText = memo(() => {
                   handleUpdateCorrectInfo({
                     ...position,
                     crtStr: recommendedWord,
+                  })
+                  sendCorrectionWordClickedEvent({
+                    sectionType: 'corrected_text',
+                    wordTextType: 'suggested',
+                    correctedErrorType: getCorrectedErrorType(
+                      position.correctMethod,
+                    ),
                   })
                 }}
               >

--- a/src/pages/speller/ui/speller-control.tsx
+++ b/src/pages/speller/ui/speller-control.tsx
@@ -4,18 +4,21 @@ import React from 'react'
 
 import { Button } from '@/shared/ui/button'
 import { TextCounter } from '@/shared/ui/text-counter'
-import { useSpeller } from '@/entities/speller'
+import { useSpeller, useStrictCheckQuery } from '@/entities/speller'
+import { sendCheckTriggeredEvent } from '@/shared/lib/send-ga-event'
 
 const SpellerControl = () => {
+  const isStrict = useStrictCheckQuery()
   const { text } = useSpeller()
 
-  const count = text.length
-  const isButtonDisabled = count <= 0
+  const textLength = text.length
+  const isButtonDisabled = textLength <= 0
 
   return (
     <div className='mt-2 flex flex-shrink-0 justify-between tab:mt-[0.625rem]'>
-      <TextCounter count={count} />
+      <TextCounter count={textLength} />
       <Button
+        onClick={() => sendCheckTriggeredEvent({ textLength, isStrict })}
         type='submit'
         variant='action'
         className='h-[3.375rem] w-[8rem] pc:h-[4.0625rem] pc:w-[9.625rem]'

--- a/src/shared/lib/analytics-event-types.ts
+++ b/src/shared/lib/analytics-event-types.ts
@@ -9,6 +9,9 @@ export const GA_ACTIONS = {
   ERROR_DETAIL_OPENED: 'error_detail_opened',
   ERROR_DETAIL_CLOSED: 'error_detail_closed',
   CORRECTION_WORD_CLICKED: 'correction_word_clicked',
+  MANUAL_CORRECTION_SUBMITTED: 'manual_correction_submitted',
+  CORRECTION_FEEDBACK_OPENED: 'correction_feedback_opened',
+  CORRECTION_FEEDBACK_SUBMITTED: 'correction_feedback_submitted',
 } as const
 
 export const GA_EVENT_TYPE = {
@@ -34,11 +37,7 @@ export const SECTION = [
   'contact_form',
   'original_text',
   'correction_item',
-  'error_report',
-  'manual_edit',
   'corrected_text',
-  'error_insight',
-  'error_anchor',
 ] as const
 export type SectionType = (typeof SECTION)[number]
 
@@ -102,6 +101,26 @@ export const CorrectionWordClickedSchema = z.object({
   corrected_error_type: z.enum(CORRECTED_ERROR_TYPE),
 })
 
+export const ManualCorrectionSubmittedSchema = z.object({
+  manual_correction_text_length: z.number(),
+  method: z.enum(METHOD),
+  section: z.enum(SECTION),
+  corrected_error_type: z.enum(CORRECTED_ERROR_TYPE),
+})
+
+export const CorrectionFeedbackOpenedSchema = z.object({
+  method: z.enum(METHOD),
+  section: z.enum(SECTION),
+  corrected_error_type: z.enum(CORRECTED_ERROR_TYPE),
+})
+
+export const CorrectionFeedbackSubmittedSchema = z.object({
+  feedback_text_length: z.number(),
+  method: z.enum(METHOD),
+  section: z.enum(SECTION),
+  corrected_error_type: z.enum(CORRECTED_ERROR_TYPE),
+})
+
 export type CheckTriggeredParams = z.infer<typeof CheckTriggeredSchema>
 export type CheckCompletedParams = z.infer<typeof CheckCompletedSchema>
 export type CheckResultNoErrorParams = z.infer<typeof CheckResultNoErrorSchema>
@@ -116,6 +135,15 @@ export type ErrorDetailClosedParams = z.infer<typeof ErrorDetailClosedSchema>
 export type CorrectionWordClickedParams = z.infer<
   typeof CorrectionWordClickedSchema
 >
+export type ManualCorrectionSubmittedParams = z.infer<
+  typeof ManualCorrectionSubmittedSchema
+>
+export type CorrectionFeedbackOpenedParams = z.infer<
+  typeof CorrectionFeedbackOpenedSchema
+>
+export type CorrectionFeedbackSubmittedParams = z.infer<
+  typeof CorrectionFeedbackSubmittedSchema
+>
 
 type GAEventMap = {
   checkTriggered: z.infer<typeof CheckTriggeredSchema>
@@ -126,6 +154,9 @@ type GAEventMap = {
   errorDetailOpened: z.infer<typeof ErrorDetailOpenedSchema>
   errorDetailClosed: z.infer<typeof ErrorDetailClosedSchema>
   correctionWordClicked: z.infer<typeof CorrectionWordClickedSchema>
+  manualCorrectionSubmitted: z.infer<typeof ManualCorrectionSubmittedSchema>
+  correctionFeedbackOpened: z.infer<typeof CorrectionFeedbackOpenedSchema>
+  correctionFeedbackSubmitted: z.infer<typeof CorrectionFeedbackSubmittedSchema>
 }
 
 export type GAEventTrackerMap = {

--- a/src/shared/lib/analytics-event-types.ts
+++ b/src/shared/lib/analytics-event-types.ts
@@ -8,6 +8,7 @@ export const GA_ACTIONS = {
   CHECK_RESULT_RESPONSE_UNKNOWN: 'check_result_response_unknown',
   ERROR_DETAIL_OPENED: 'error_detail_opened',
   ERROR_DETAIL_CLOSED: 'error_detail_closed',
+  CORRECTION_WORD_CLICKED: 'correction_word_clicked',
 } as const
 
 export const GA_EVENT_TYPE = {
@@ -23,15 +24,23 @@ export const METHOD = ['button', 'keyboard', 'drag', 'hover'] as const
 const CORRECTED_ERROR_TYPE = ['spacing', 'typo', 'context'] as const
 export type CorrectedErrorType = (typeof CORRECTED_ERROR_TYPE)[number]
 
+// suggested: 1순위 대치어
+// original: 원문
+// corrected_list: 대치어 리스트
+const WORD_TEXT_TYPE = ['corrected_list', 'original', 'suggested'] as const
+export type WordTextType = (typeof WORD_TEXT_TYPE)[number]
+
 export const SECTION = [
-  'original_text',
   'contact_form',
+  'original_text',
+  'correction_item',
   'error_report',
   'manual_edit',
   'corrected_text',
   'error_insight',
   'error_anchor',
 ] as const
+export type SectionType = (typeof SECTION)[number]
 
 export const ERROR_STAGE = ['unknown', 'timeout', 'request'] as const
 
@@ -86,6 +95,13 @@ export const ErrorDetailClosedSchema = z.object({
   section: z.enum(SECTION),
 })
 
+export const CorrectionWordClickedSchema = z.object({
+  word_text_type: z.enum(WORD_TEXT_TYPE),
+  method: z.enum(METHOD),
+  section: z.enum(SECTION),
+  corrected_error_type: z.enum(CORRECTED_ERROR_TYPE),
+})
+
 export type CheckTriggeredParams = z.infer<typeof CheckTriggeredSchema>
 export type CheckCompletedParams = z.infer<typeof CheckCompletedSchema>
 export type CheckResultNoErrorParams = z.infer<typeof CheckResultNoErrorSchema>
@@ -97,6 +113,9 @@ export type CheckResultResponseUnknownParams = z.infer<
 >
 export type ErrorDetailOpenedParams = z.infer<typeof ErrorDetailOpenedSchema>
 export type ErrorDetailClosedParams = z.infer<typeof ErrorDetailClosedSchema>
+export type CorrectionWordClickedParams = z.infer<
+  typeof CorrectionWordClickedSchema
+>
 
 type GAEventMap = {
   checkTriggered: z.infer<typeof CheckTriggeredSchema>
@@ -106,6 +125,7 @@ type GAEventMap = {
   checkResultResponseUnknown: z.infer<typeof CheckResultResponseUnknownSchema>
   errorDetailOpened: z.infer<typeof ErrorDetailOpenedSchema>
   errorDetailClosed: z.infer<typeof ErrorDetailClosedSchema>
+  correctionWordClicked: z.infer<typeof CorrectionWordClickedSchema>
 }
 
 export type GAEventTrackerMap = {

--- a/src/shared/lib/analytics-event-types.ts
+++ b/src/shared/lib/analytics-event-types.ts
@@ -2,6 +2,10 @@ import { z } from 'zod'
 
 export const GA_ACTIONS = {
   CHECK_TRIGGERED: 'check_triggered',
+  CHECK_COMPLETED: 'check_completed',
+  CHECK_RESULT_NO_ERROR: 'check_result_no_error',
+  CHECK_RESULT_RESPONSE_ERROR: 'check_result_response_error',
+  CHECK_RESULT_RESPONSE_UNKNOWN: 'check_result_response_unknown',
 } as const
 
 export const GA_EVENT_TYPE = {
@@ -9,8 +13,8 @@ export const GA_EVENT_TYPE = {
   EXCEPTION: 'exception',
 } as const
 
-// 파라미터 정의
 export const METHOD = ['button', 'keyboard', 'drag', 'hover'] as const
+
 export const SECTION = [
   'original_text',
   'contact_form',
@@ -21,6 +25,8 @@ export const SECTION = [
   'error_anchor',
 ] as const
 
+export const ERROR_STAGE = ['unknown', 'timeout', 'request'] as const
+
 export const CheckTriggeredSchema = z.object({
   original_text_length: z.number(),
   method: z.enum(METHOD),
@@ -28,10 +34,54 @@ export const CheckTriggeredSchema = z.object({
   is_strict: z.boolean(),
 })
 
+export const CheckCompletedSchema = z.object({
+  original_text_length: z.number(),
+  section: z.enum(SECTION),
+  is_strict: z.boolean(),
+  elapsed_time_ms: z.number(),
+})
+
+export const CheckResultNoErrorSchema = z.object({
+  original_text_length: z.number(),
+  section: z.enum(SECTION),
+  is_strict: z.boolean(),
+  elapsed_time_ms: z.number(),
+})
+
+export const CheckResultResponseErrorSchema = z.object({
+  error_stage: z.enum(ERROR_STAGE),
+  error_code: z.number(),
+  error_message: z.string(),
+  original_text_length: z.number(),
+  section: z.enum(SECTION),
+  is_strict: z.boolean(),
+  elapsed_time_ms: z.number(),
+})
+
+export const CheckResultResponseUnknownSchema = z.object({
+  error_stage: z.enum(ERROR_STAGE),
+  error_code: z.number(),
+  error_message: z.string(),
+  section: z.enum(SECTION),
+  elapsed_time_ms: z.number(),
+})
+
 export type CheckTriggeredParams = z.infer<typeof CheckTriggeredSchema>
+export type CheckCompletedParams = z.infer<typeof CheckCompletedSchema>
+export type CheckResultNoErrorParams = z.infer<typeof CheckResultNoErrorSchema>
+export type CheckResultResponseErrorParams = z.infer<
+  typeof CheckResultResponseErrorSchema
+>
+export type CheckResultResponseUnknownParams = z.infer<
+  typeof CheckResultResponseUnknownSchema
+>
 
 type GAEventMap = {
   checkTriggered: z.infer<typeof CheckTriggeredSchema>
+  checkCompleted: z.infer<typeof CheckCompletedSchema>
+  checkResultNoError: z.infer<typeof CheckResultNoErrorSchema>
+  checkResultResponseError: z.infer<typeof CheckResultResponseErrorSchema>
+  checkResultResponseUnknown: z.infer<typeof CheckResultResponseUnknownSchema>
 }
 
 export type GAEventTrackerMap = {

--- a/src/shared/lib/analytics-event-types.ts
+++ b/src/shared/lib/analytics-event-types.ts
@@ -6,6 +6,8 @@ export const GA_ACTIONS = {
   CHECK_RESULT_NO_ERROR: 'check_result_no_error',
   CHECK_RESULT_RESPONSE_ERROR: 'check_result_response_error',
   CHECK_RESULT_RESPONSE_UNKNOWN: 'check_result_response_unknown',
+  ERROR_DETAIL_OPENED: 'error_detail_opened',
+  ERROR_DETAIL_CLOSED: 'error_detail_closed',
 } as const
 
 export const GA_EVENT_TYPE = {
@@ -14,6 +16,12 @@ export const GA_EVENT_TYPE = {
 } as const
 
 export const METHOD = ['button', 'keyboard', 'drag', 'hover'] as const
+
+// spacing: 띄어쓰기 오류
+// typo: 오탈자 오류
+// context: 문맥상 오류
+const CORRECTED_ERROR_TYPE = ['spacing', 'typo', 'context'] as const
+export type CorrectedErrorType = (typeof CORRECTED_ERROR_TYPE)[number]
 
 export const SECTION = [
   'original_text',
@@ -66,6 +74,18 @@ export const CheckResultResponseUnknownSchema = z.object({
   elapsed_time_ms: z.number(),
 })
 
+export const ErrorDetailOpenedSchema = z.object({
+  corrected_error_type: z.enum(CORRECTED_ERROR_TYPE),
+  method: z.enum(METHOD),
+  section: z.enum(SECTION),
+})
+
+export const ErrorDetailClosedSchema = z.object({
+  corrected_error_type: z.enum(CORRECTED_ERROR_TYPE),
+  method: z.enum(METHOD),
+  section: z.enum(SECTION),
+})
+
 export type CheckTriggeredParams = z.infer<typeof CheckTriggeredSchema>
 export type CheckCompletedParams = z.infer<typeof CheckCompletedSchema>
 export type CheckResultNoErrorParams = z.infer<typeof CheckResultNoErrorSchema>
@@ -75,6 +95,8 @@ export type CheckResultResponseErrorParams = z.infer<
 export type CheckResultResponseUnknownParams = z.infer<
   typeof CheckResultResponseUnknownSchema
 >
+export type ErrorDetailOpenedParams = z.infer<typeof ErrorDetailOpenedSchema>
+export type ErrorDetailClosedParams = z.infer<typeof ErrorDetailClosedSchema>
 
 type GAEventMap = {
   checkTriggered: z.infer<typeof CheckTriggeredSchema>
@@ -82,6 +104,8 @@ type GAEventMap = {
   checkResultNoError: z.infer<typeof CheckResultNoErrorSchema>
   checkResultResponseError: z.infer<typeof CheckResultResponseErrorSchema>
   checkResultResponseUnknown: z.infer<typeof CheckResultResponseUnknownSchema>
+  errorDetailOpened: z.infer<typeof ErrorDetailOpenedSchema>
+  errorDetailClosed: z.infer<typeof ErrorDetailClosedSchema>
 }
 
 export type GAEventTrackerMap = {

--- a/src/shared/lib/analytics-event-types.ts
+++ b/src/shared/lib/analytics-event-types.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+
+export const GA_ACTIONS = {
+  CHECK_TRIGGERED: 'check_triggered',
+} as const
+
+export const GA_EVENT_TYPE = {
+  EVENT: 'event',
+  EXCEPTION: 'exception',
+} as const
+
+// 파라미터 정의
+export const METHOD = ['button', 'keyboard', 'drag', 'hover'] as const
+export const SECTION = [
+  'original_text',
+  'contact_form',
+  'error_report',
+  'manual_edit',
+  'corrected_text',
+  'error_insight',
+  'error_anchor',
+] as const
+
+export const CheckTriggeredSchema = z.object({
+  original_text_length: z.number(),
+  method: z.enum(METHOD),
+  section: z.enum(SECTION),
+  is_strict: z.boolean(),
+})
+
+export type CheckTriggeredParams = z.infer<typeof CheckTriggeredSchema>
+
+type GAEventMap = {
+  checkTriggered: z.infer<typeof CheckTriggeredSchema>
+}
+
+export type GAEventTrackerMap = {
+  [K in keyof GAEventMap]: (params: GAEventMap[K]) => void
+}

--- a/src/shared/lib/google-analytics-script.tsx
+++ b/src/shared/lib/google-analytics-script.tsx
@@ -1,0 +1,13 @@
+import { GoogleAnalytics } from '@next/third-parties/google'
+
+const GA4_ID = process.env.NEXT_PUBLIC_GA4_ID
+
+const GoogleAnalyticsScript = () => {
+  if (!GA4_ID) {
+    throw new Error('Missing NEXT_PUBLIC_GA4_ID')
+  }
+
+  return <GoogleAnalytics gaId={GA4_ID} />
+}
+
+export { GoogleAnalyticsScript }

--- a/src/shared/lib/send-ga-event.ts
+++ b/src/shared/lib/send-ga-event.ts
@@ -14,6 +14,9 @@ import {
   CheckResultResponseUnknownParams,
   ErrorDetailOpenedParams,
   CorrectedErrorType,
+  CorrectionWordClickedParams,
+  WordTextType,
+  SectionType,
 } from './analytics-event-types'
 
 type Event = (typeof GA_EVENT_TYPE)[keyof typeof GA_EVENT_TYPE]
@@ -57,6 +60,10 @@ const GAEvents: GAEventTrackerMap = {
   errorDetailClosed: createTracker<ErrorDetailOpenedParams>(
     GA_EVENT_TYPE.EVENT,
     GA_ACTIONS.ERROR_DETAIL_CLOSED,
+  ),
+  correctionWordClicked: createTracker<CorrectionWordClickedParams>(
+    GA_EVENT_TYPE.EVENT,
+    GA_ACTIONS.CORRECTION_WORD_CLICKED,
   ),
 }
 
@@ -248,5 +255,29 @@ export const sendErrorDetailClosedEvent = ({
     method: 'button',
     section: 'error_insight',
     corrected_error_type: correctedErrorType,
+  })
+}
+
+/**
+ * 사용자가 대치어(수정된 단어)를 클릭했을 때 GA 이벤트를 전송합니다.
+ *
+ * @param correctedErrorType 해당 단어에 적용된 교정 오류 유형
+ * @param wordTextType 클릭된 단어의 위치 구분
+ * @param sectionType 클릭된 단어의 섹션 구분 (교정 문서, 맞춤법/문법 오류)
+ */
+export const sendCorrectionWordClickedEvent = ({
+  correctedErrorType,
+  wordTextType,
+  sectionType,
+}: {
+  correctedErrorType: CorrectedErrorType
+  wordTextType: WordTextType
+  sectionType: SectionType
+}) => {
+  GAEvents.correctionWordClicked({
+    word_text_type: wordTextType,
+    corrected_error_type: correctedErrorType,
+    section: sectionType,
+    method: 'button',
   })
 }

--- a/src/shared/lib/send-ga-event.ts
+++ b/src/shared/lib/send-ga-event.ts
@@ -12,6 +12,8 @@ import {
   CheckResultResponseErrorParams,
   ERROR_STAGE,
   CheckResultResponseUnknownParams,
+  ErrorDetailOpenedParams,
+  CorrectedErrorType,
 } from './analytics-event-types'
 
 type Event = (typeof GA_EVENT_TYPE)[keyof typeof GA_EVENT_TYPE]
@@ -47,6 +49,14 @@ const GAEvents: GAEventTrackerMap = {
   checkResultResponseUnknown: createTracker<CheckResultResponseUnknownParams>(
     GA_EVENT_TYPE.EVENT,
     GA_ACTIONS.CHECK_RESULT_RESPONSE_UNKNOWN,
+  ),
+  errorDetailOpened: createTracker<ErrorDetailOpenedParams>(
+    GA_EVENT_TYPE.EVENT,
+    GA_ACTIONS.ERROR_DETAIL_OPENED,
+  ),
+  errorDetailClosed: createTracker<ErrorDetailOpenedParams>(
+    GA_EVENT_TYPE.EVENT,
+    GA_ACTIONS.ERROR_DETAIL_CLOSED,
   ),
 }
 
@@ -198,5 +208,45 @@ export const sendCheckResultResponseUnknownEvent = ({
     error_message: errorMessage,
     elapsed_time_ms: elapsedTimeMs,
     section: 'original_text',
+  })
+}
+
+/**
+ * 사용자가 교정 오류 상세 정보를 열었을 때 GA 이벤트를 전송합니다.
+ *
+ * - 예: 사용자가 특정 맞춤법/문법 오류 항목을 클릭하여 상세 설명을 확인한 경우
+ * - 이벤트는 'button' 방식으로, 'error_insight' 섹션에서 발생한 것으로 기록됩니다.
+ *
+ * @param correctedErrorType 열람한 오류 유형 (띄어쓰기, 오탈자, 문맥)
+ */
+export const sendErrorDetailOpenedEvent = ({
+  correctedErrorType,
+}: {
+  correctedErrorType: CorrectedErrorType
+}) => {
+  GAEvents.errorDetailOpened({
+    method: 'button',
+    section: 'error_insight',
+    corrected_error_type: correctedErrorType,
+  })
+}
+
+/**
+ * 사용자가 교정 오류 상세 정보를 닫았을 때 GA 이벤트를 전송합니다.
+ *
+ * - 예: 사용자가 열린 오류 상세 설명 패널을 닫은 경우
+ * - 이벤트는 'button' 방식으로, 'error_insight' 섹션에서 발생한 것으로 기록됩니다.
+ *
+ * @param correctedErrorType 닫은 오류 유형 (띄어쓰기, 오탈자, 문맥)
+ */
+export const sendErrorDetailClosedEvent = ({
+  correctedErrorType,
+}: {
+  correctedErrorType: CorrectedErrorType
+}) => {
+  GAEvents.errorDetailClosed({
+    method: 'button',
+    section: 'error_insight',
+    corrected_error_type: correctedErrorType,
   })
 }

--- a/src/shared/lib/send-ga-event.ts
+++ b/src/shared/lib/send-ga-event.ts
@@ -1,0 +1,54 @@
+'use client'
+
+import { sendGAEvent } from '@next/third-parties/google'
+
+import {
+  GA_ACTIONS,
+  GA_EVENT_TYPE,
+  GAEventTrackerMap,
+  CheckTriggeredParams,
+} from './analytics-event-types'
+
+type Event = (typeof GA_EVENT_TYPE)[keyof typeof GA_EVENT_TYPE]
+type Action = (typeof GA_ACTIONS)[keyof typeof GA_ACTIONS]
+type Params = Record<string, unknown>
+
+type CreateTracker = <TParams extends Params>(
+  event: Event,
+  action: Action,
+) => (params: TParams) => void
+
+const createTracker: CreateTracker = (event, action) => params => {
+  sendGAEvent(event, action, { ...params })
+}
+
+const GAEvents: GAEventTrackerMap = {
+  checkTriggered: createTracker<CheckTriggeredParams>(
+    GA_EVENT_TYPE.EVENT,
+    GA_ACTIONS.CHECK_TRIGGERED,
+  ),
+}
+
+/**
+ * 검사하기 버튼 클릭 시 호출되는 GA 이벤트 함수
+ *
+ * 사용자의 입력 길이, 검사 방식(강한 검사 여부) 등의 정보를 포함해
+ * 'checkTriggered' 이벤트를 Google Analytics에 전송합니다.
+ *
+ * @param textLength 사용자가 입력한 원문 텍스트 길이
+ * @param isStrict 강한 검사 모드 여부 (true: 강한 검사, false: 일반 검사)
+ */
+export const sendCheckTriggeredEvent = ({
+  textLength,
+  isStrict,
+}: {
+  textLength: number
+  isStrict: boolean
+}) => {
+  GAEvents.checkTriggered({
+    original_text_length: textLength,
+    method: 'button',
+    section: 'original_text',
+    is_strict: isStrict,
+  })
+}

--- a/src/shared/lib/send-ga-event.ts
+++ b/src/shared/lib/send-ga-event.ts
@@ -7,6 +7,11 @@ import {
   GA_EVENT_TYPE,
   GAEventTrackerMap,
   CheckTriggeredParams,
+  CheckCompletedParams,
+  CheckResultNoErrorParams,
+  CheckResultResponseErrorParams,
+  ERROR_STAGE,
+  CheckResultResponseUnknownParams,
 } from './analytics-event-types'
 
 type Event = (typeof GA_EVENT_TYPE)[keyof typeof GA_EVENT_TYPE]
@@ -26,6 +31,22 @@ const GAEvents: GAEventTrackerMap = {
   checkTriggered: createTracker<CheckTriggeredParams>(
     GA_EVENT_TYPE.EVENT,
     GA_ACTIONS.CHECK_TRIGGERED,
+  ),
+  checkCompleted: createTracker<CheckCompletedParams>(
+    GA_EVENT_TYPE.EVENT,
+    GA_ACTIONS.CHECK_COMPLETED,
+  ),
+  checkResultNoError: createTracker<CheckResultNoErrorParams>(
+    GA_EVENT_TYPE.EVENT,
+    GA_ACTIONS.CHECK_RESULT_NO_ERROR,
+  ),
+  checkResultResponseError: createTracker<CheckResultResponseErrorParams>(
+    GA_EVENT_TYPE.EVENT,
+    GA_ACTIONS.CHECK_RESULT_RESPONSE_ERROR,
+  ),
+  checkResultResponseUnknown: createTracker<CheckResultResponseUnknownParams>(
+    GA_EVENT_TYPE.EVENT,
+    GA_ACTIONS.CHECK_RESULT_RESPONSE_UNKNOWN,
   ),
 }
 
@@ -50,5 +71,132 @@ export const sendCheckTriggeredEvent = ({
     method: 'button',
     section: 'original_text',
     is_strict: isStrict,
+  })
+}
+
+/**
+ * 검사 완료 시점에 호출되는 GA 이벤트 함수
+ *
+ * 사용자의 입력 길이, 검사 소요 시간, 강한 검사 여부 등의 정보를 포함해
+ * 'checkCompleted' 이벤트를 Google Analytics에 전송합니다.
+ *
+ * @param textLength 사용자가 입력한 원문의 글자 수
+ * @param elapsedTimeMs 검사 요청부터 응답까지 소요된 시간 (밀리초 단위)
+ * @param isStrict 강한 검사 모드 여부 (true: 강한 검사, false: 일반 검사)
+ */
+export const sendCheckCompletedEvent = ({
+  textLength,
+  elapsedTimeMs,
+  isStrict,
+}: {
+  textLength: number
+  elapsedTimeMs: number
+  isStrict: boolean
+}) => {
+  GAEvents.checkCompleted({
+    original_text_length: textLength,
+    elapsed_time_ms: elapsedTimeMs,
+    section: 'original_text',
+    is_strict: isStrict,
+  })
+}
+
+/**
+ * 검사 결과에 맞춤법/문법 오류가 없는 경우 호출되는 GA 이벤트 함수
+ *
+ * 사용자가 검사하기를 실행한 후, 서버 응답 결과에 오류가 하나도 없을 때만
+ * 'checkResultNoError' 이벤트를 Google Analytics로 전송합니다.
+ *
+ * @param textLength 검사한 원문의 글자 수
+ * @param elapsedTimeMs 검사 요청부터 응답까지 소요된 시간 (밀리초 단위)
+ * @param isStrict 강한 검사 모드 여부 (true: 강한 검사, false: 일반 검사)
+ */
+export const sendCheckResultNoErrorEvent = ({
+  textLength,
+  elapsedTimeMs,
+  isStrict,
+}: {
+  textLength: number
+  elapsedTimeMs: number
+  isStrict: boolean
+}) => {
+  GAEvents.checkResultNoError({
+    original_text_length: textLength,
+    elapsed_time_ms: elapsedTimeMs,
+    section: 'original_text',
+    is_strict: isStrict,
+  })
+}
+
+/**
+ * 검사 결과 응답 처리 중 에러가 발생했을 때 호출되는 GA 이벤트 함수
+ *
+ * 맞춤법 검사 API 응답 처리 중 발생한 오류 정보를
+ * Google Analytics에 이벤트로 전송합니다.
+ * 에러의 발생 단계(`error_stage`)를 명시하여
+ * 어떤 유형의 오류인지 등을 구분할 수 있도록 구성되어 있습니다.
+ *
+ * @param textLength 검사 대상 원문의 글자 수
+ * @param elapsedTimeMs 요청 시작부터 오류 발생까지의 소요 시간 (밀리초 단위)
+ * @param isStrict 강한 검사 모드 여부 (true: 강한 검사, false: 일반 검사)
+ * @param errorStage 오류 발생 단계 (예: 'request', 'timeout' 등)
+ * @param errorCode 서버 또는 내부 시스템이 부여한 오류 코드
+ * @param errorMessage 에러 메시지 또는 상세 설명
+ */
+export const sendCheckResultResponseErrorEvent = ({
+  textLength,
+  elapsedTimeMs,
+  isStrict,
+  errorStage,
+  errorCode,
+  errorMessage,
+}: {
+  textLength: number
+  elapsedTimeMs: number
+  isStrict: boolean
+  errorCode: number
+  errorStage: (typeof ERROR_STAGE)[number]
+  errorMessage: string
+}) => {
+  GAEvents.checkResultResponseError({
+    original_text_length: textLength,
+    error_stage: errorStage,
+    error_code: errorCode,
+    error_message: errorMessage,
+    elapsed_time_ms: elapsedTimeMs,
+    section: 'original_text',
+    is_strict: isStrict,
+  })
+}
+
+/**
+ * 맞춤법 검사 응답 처리 중 예상하지 못한 오류가 발생한 경우 GA 이벤트를 전송합니다.
+ *
+ * 응답 처리 흐름 상에서 오류 코드 및 메시지를 수신했지만,
+ * 요청 정보나 사용자의 입력 상태 등 추가 맥락을 파악할 수 없을 때 호출됩니다.
+ * 예를 들어, 요청 payload가 파싱되지 않거나 오류가 명확하게 분류되지 않는 경우 등에 해당합니다.
+ *
+ * @param elapsedTimeMs 요청 시작부터 예외 발생까지의 소요 시간 (밀리초 단위)
+ * @param errorCode 서버 또는 내부 시스템이 부여한 오류 코드
+ * @param errorStage 오류 발생 단계 (예: 'unknown' 등)
+ * @param errorMessage 에러 메시지 또는 상세 설명
+ */
+export const sendCheckResultResponseUnknownEvent = ({
+  elapsedTimeMs,
+  errorStage,
+  errorCode,
+  errorMessage,
+}: {
+  elapsedTimeMs: number
+  errorCode: number
+  errorStage: (typeof ERROR_STAGE)[number]
+  errorMessage: string
+}) => {
+  GAEvents.checkResultResponseUnknown({
+    error_stage: errorStage,
+    error_code: errorCode,
+    error_message: errorMessage,
+    elapsed_time_ms: elapsedTimeMs,
+    section: 'original_text',
   })
 }


### PR DESCRIPTION
맞춤법 검사기 서비스에 GA4 기반 주요 사용자 행동 이벤트를 추가하여
초기 사용 흐름 파악, 에러 현황 진단, UI 상호작용률 수집이 가능하도록 구성했습니다.

1. 검사 흐름 전반 측정
- 검사 요청 시점: check_triggered 이벤트 전송
- 검사 완료 시점: check_completed 이벤트 전송
-검사 처리 시간(ms): elapsed_time_ms 파라미터로 측정

2. 에러 발생 시 GA 로깅
- check_result_response_error: 서버 응답 실패 또는 타임아웃 발생 시 로깅
- check_result_response_unknown: 예외 또는 클라이언트 측 처리 실패 시 로깅
- 오류 코드 (error_code), 단계 (error_stage) 등 상세 정보 포함

3. 도움말 클릭률
- ‘자세히 보기’ 클릭 시 error_detail_opened / error_detail_closed 이벤트 전송

4. 대치어 수정 클릭률
- 왼쪽/오른쪽 화면에서의 대치어 수정 클릭시 correction_word_clicked 이벤트 전송
(대치어 리스트 단어 클릭은 1차에서 제외되었습니다.)

5. 오류 제보 버튼 클릭 및 전송률
- 오류 제보 버튼 클릭 시 correction_feedback_opened
- 실제 전송 시 correction_feedback_submitted
→ 오류 유형, 제보 길이, 섹션 정보 포함

6. 대치어 직접 수정률
- 사용자가 대치어를 직접 입력 후 제출한 경우 manual_correction_submitted 이벤트 전송

![스크린샷 2025-05-21 오후 2 41 15](https://github.com/user-attachments/assets/36eba9d5-31c9-45f3-ba4f-4951116df475)

불필요한 파라미터나 흐름을 일부 축소하였습니다.

[GA4 설계 전략 제안서(1.1).pdf](https://github.com/user-attachments/files/20380592/GA4.1.1.pdf)



새로운 환경변수 추가가 필요합니다.
아래는 개발용 ID입니다.
```
# .env.development

NEXT_PUBLIC_GA4_ID=G-QBMDVWVF0L
```

etc
- next 버전 업데이트에 따라 구성 설정을 일부 수정했습니다.