### PR TITLE
feat: 자동 스크롤 ON/OFF 기능 (#236)

### DIFF
--- a/src/entities/speller/model/speller-slice.ts
+++ b/src/entities/speller/model/speller-slice.ts
@@ -9,12 +9,13 @@ type Response = CheckResponse & { requestedWithStrictMode: boolean }
 
 interface SpellerState {
   text: string // 입력된 텍스트 원본
-  displayText: string // 교정문서에 표시되는 텍스트
-  isStrictCheck: boolean // 강한 검사
-  response: Response
-  responseMap: Record<number, Response>
-  correctInfo: Record<number, CorrectInfo>
-  selectedErrIdx: number
+  displayText: string // 교정 문서에 표시되는 텍스트
+  isStrictCheck: boolean // 강한 검사 여부
+  response: Response // 검사 결과
+  responseMap: Record<number, Response> // 페이지별 검사 결과
+  correctInfo: Record<number, CorrectInfo> // 오류 정보
+  selectedErrIdx: number // 선택된 오류 인덱스
+  isAutoScroll: boolean // 자동 스크롤 여부
 }
 
 const initialState: SpellerState = {
@@ -31,6 +32,7 @@ const initialState: SpellerState = {
   responseMap: {},
   correctInfo: {},
   selectedErrIdx: -1,
+  isAutoScroll: true,
 }
 
 const spellerSlice = createSlice({
@@ -40,11 +42,9 @@ const spellerSlice = createSlice({
     setText: (state, action: PayloadAction<string>) => {
       state.text = action.payload
     },
-
     setStrictMode: (state, action: PayloadAction<boolean>) => {
       state.isStrictCheck = action.payload
     },
-
     updateResponse: (state, action: PayloadAction<Response>) => {
       state.displayText = action.payload.str
       state.response = action.payload
@@ -53,7 +53,6 @@ const spellerSlice = createSlice({
         {},
       )
     },
-
     updateCorrectInfo: (state, action: PayloadAction<CorrectInfo>) => {
       state.correctInfo[action.payload.errorIdx] = action.payload
 
@@ -62,11 +61,9 @@ const spellerSlice = createSlice({
         state.correctInfo,
       )
     },
-
     setSelectedErrIdx: (state, action: PayloadAction<number>) => {
       state.selectedErrIdx = action.payload
     },
-
     setResponseMap: (
       state,
       action: PayloadAction<Response & { pageIdx: number }>,
@@ -74,9 +71,11 @@ const spellerSlice = createSlice({
       const { pageIdx, ...response } = action.payload
       state.responseMap[pageIdx] = response
     },
-
     resetResponseMap: state => {
       state.responseMap = {}
+    },
+    setIsAutoScroll: (state, action: PayloadAction<boolean>) => {
+      state.isAutoScroll = action.payload
     },
   },
 })
@@ -89,6 +88,7 @@ const {
   setSelectedErrIdx,
   setResponseMap,
   resetResponseMap,
+  setIsAutoScroll,
 } = spellerSlice.actions
 const spellerReducer = spellerSlice.reducer
 
@@ -100,6 +100,7 @@ export {
   setSelectedErrIdx,
   setResponseMap,
   resetResponseMap,
+  setIsAutoScroll,
   spellerReducer,
   type SpellerState,
 }

--- a/src/entities/speller/model/use-speller.ts
+++ b/src/entities/speller/model/use-speller.ts
@@ -11,8 +11,9 @@ import {
   setSelectedErrIdx,
   setResponseMap,
   resetResponseMap,
-  type SpellerState,
   setStrictMode,
+  setIsAutoScroll,
+  type SpellerState,
 } from './speller-slice'
 import { CorrectInfo } from './speller-schema'
 
@@ -66,6 +67,13 @@ const useSpeller = () => {
     dispatch(resetResponseMap())
   }, [dispatch])
 
+  const updateIsAutoScroll = useCallback(
+    (value: boolean) => {
+      dispatch(setIsAutoScroll(value))
+    },
+    [dispatch],
+  )
+
   return {
     ...state,
     handleTextChange,
@@ -75,6 +83,7 @@ const useSpeller = () => {
     updateErrInfoIndex,
     updateResponseMap,
     initResponseMap,
+    updateIsAutoScroll,
   }
 }
 

--- a/src/pages/results/ui/correction-content.tsx
+++ b/src/pages/results/ui/correction-content.tsx
@@ -5,10 +5,12 @@ import React from 'react'
 import { SpellingCorrectionText } from './spelling-correction-text'
 import { ScrollGradientFade } from '@/shared/ui/scroll-gradient-fade'
 import { ScrollContainer } from '@/shared/ui/scroll-container'
-import { useSpellerRefs } from '@/entities/speller'
+import { useSpeller, useSpellerRefs } from '@/entities/speller'
+import { Switch } from '@/shared/ui/switch'
 
 const CorrectionContent = () => {
   const { correctScrollContainerRef } = useSpellerRefs()
+  const { isAutoScroll, updateIsAutoScroll } = useSpeller()
 
   return (
     <>
@@ -17,6 +19,12 @@ const CorrectionContent = () => {
         <h2 className='text-lg font-semibold leading-[1.9125rem] tracking-[-0.0225rem] tab:text-[1.375rem] tab:leading-[2.3375rem] tab:tracking-[-0.0275rem] pc:text-[1.5rem] pc:leading-[2.55rem] pc:tracking-[-0.03rem]'>
           교정 문서
         </h2>
+        <div className='flex items-center gap-2'>
+          <span className='text-base text-slate-600 pc:text-xl'>
+            자동스크롤
+          </span>
+          <Switch checked={isAutoScroll} onCheckedChange={updateIsAutoScroll} />
+        </div>
       </div>
       {/* 교정 텍스트 */}
       <div className='min-w-0 flex-1'>

--- a/src/pages/results/ui/error-tracking-section.tsx
+++ b/src/pages/results/ui/error-tracking-section.tsx
@@ -14,7 +14,7 @@ import { BulletBadge } from '../ui/bullet-badge'
 
 const ErrorTrackingSection = () => {
   const { errorRefs, errorScrollContainerRef, scrollSection } = useSpellerRefs()
-  const { response } = useSpeller()
+  const { response, isAutoScroll } = useSpeller()
   const { errInfo } = response ?? {}
 
   return (
@@ -42,7 +42,10 @@ const ErrorTrackingSection = () => {
                   if (!errorRefs || !el) return
                   errorRefs.current[idx] = el
                 }}
-                onMouseOver={() => scrollSection('correct', idx)}
+                onMouseOver={() => {
+                  if (!isAutoScroll) return
+                  scrollSection('correct', idx)
+                }}
               />
             </Fragment>
           ))}

--- a/src/pages/results/ui/spelling-correction-text.tsx
+++ b/src/pages/results/ui/spelling-correction-text.tsx
@@ -12,7 +12,8 @@ import { getCorrectedErrorType } from '@/entities/speller/lib/get-corrected-erro
 
 const SpellingCorrectionText = memo(() => {
   const { correctRefs, scrollSection } = useSpellerRefs()
-  const { response, correctInfo, handleUpdateCorrectInfo } = useSpeller()
+  const { response, correctInfo, isAutoScroll, handleUpdateCorrectInfo } =
+    useSpeller()
   const { str: text } = response
 
   const parts = useMemo(() => {
@@ -45,7 +46,10 @@ const SpellingCorrectionText = memo(() => {
                 if (!correctRefs || !el) return
                 correctRefs.current[currentIndex] = el
               }}
-              onMouseOver={() => scrollSection('error', currentIndex)}
+              onMouseOver={() => {
+                if (!isAutoScroll) return
+                scrollSection('error', currentIndex)
+              }}
               aria-label={`추천 단어 - ${recommendedWord}`}
             >
               <button
@@ -93,7 +97,7 @@ const SpellingCorrectionText = memo(() => {
         },
       },
     })
-  }, [correctInfo, response.str])
+  }, [correctInfo, response.str, isAutoScroll])
 
   return (
     <div


### PR DESCRIPTION
## 작업 내역
- 교정 문서 섹션과 맞춤법/문법 오류 섹션 내 단어들에 마우스 오버할 경우 자동 스크롤되는 기능을 on/off 하는 기능을 추가했습니다.

## 스크린샷
<img width="630" height="542" alt="스크린샷 2025-07-14 오후 6 02 51" src="https://github.com/user-attachments/assets/98ef1797-dc2b-44d5-8de1-91cc2fd1b329" />
<img width="425" height="553" alt="스크린샷 2025-07-14 오후 6 03 10" src="https://github.com/user-attachments/assets/f748b74e-991b-498e-b498-b2c2fa8562dd" />

close #236 