### PR TITLE
feat: about 페이지 추가 (#250)

### DIFF
--- a/app/(base-layout)/about/page.tsx
+++ b/app/(base-layout)/about/page.tsx
@@ -1,0 +1,3 @@
+import { AboutPage } from '@/pages/about'
+
+export default AboutPage

--- a/src/pages/about/index.ts
+++ b/src/pages/about/index.ts
@@ -1,0 +1,1 @@
+export { AboutPage } from './ui/about-page'

--- a/src/pages/about/ui/about-page.tsx
+++ b/src/pages/about/ui/about-page.tsx
@@ -1,7 +1,3 @@
-import { CONTACT_INFO } from '@/shared/model/contact-info'
-import Image from 'next/image'
-import Link from 'next/link'
-
 export const AboutPage = () => {
   return (
     <div className='flex w-full flex-col items-center px-4 py-10 pc:py-16'>
@@ -18,61 +14,18 @@ export const AboutPage = () => {
           </a>
         </div>
 
-        {/* 고객센터 및 문의 */}
-        <div className='flex flex-col items-center gap-3 rounded-lg bg-slate-100 p-4 pc:flex-row pc:justify-center'>
-          <div className='flex flex-col items-center gap-1 pc:flex-row pc:justify-center'>
-            <span className='text-xs font-semibold tracking-[-0.015rem] pc:text-sm'>
-              <Link
-                href='/order'
-                className='hover:text-primary hover:underline'
-              >
-                구매문의
-              </Link>
-            </span>
-            <a
-              href={`tel:${CONTACT_INFO.tel.value}`}
-              className='text-slate-700 flex items-center gap-1 text-xs hover:text-primary'
-            >
-              <div className='relative size-4'>
-                <Image
-                  className='object-cover'
-                  src='/call.svg'
-                  alt='전화 아이콘'
-                  fill
-                />
-              </div>
-              <span>{CONTACT_INFO.tel.label}</span>
-            </a>
-            <a
-              href={`mailto:${CONTACT_INFO.email.value}`}
-              className='text-slate-700 flex items-center gap-1 text-xs hover:text-primary'
-            >
-              <div className='relative size-4'>
-                <Image
-                  className='object-cover'
-                  src='/email.svg'
-                  alt='이메일 아이콘'
-                  fill
-                />
-              </div>
-              <span>{CONTACT_INFO.email.label}</span>
-            </a>
-          </div>
-        </div>
-
         {/* 저작권 및 소개 */}
         <div className='flex flex-col gap-2 text-center text-xs text-slate-500 pc:text-sm'>
           {/* PC/모바일 반응형 소개 */}
-          <div>
-            <p className='pc:hidden'>바른 한글은 부산대학교 인공지능연구실과</p>
-            <p className='pc:hidden'>
-              (주)나라인포테크가 함께 만들고 있습니다.
-            </p>
-            <p className='hidden pc:block'>
-              바른 한글은 부산대학교 인공지능연구실과 (주)나라인포테크가 함께
-              만들고 있습니다.
-            </p>
-          </div>
+          <p>
+            &apos;바른한글&apos;은 &apos;한국어 맞춤법/문법 검사기&apos;의 새
+            이름입니다.
+          </p>
+          <p>
+            &apos;한국어 맞춤법/문법 검사기&apos;는 인공지능연구실과
+            (주)나라인포테크가 함께 만들었으며, 현재는 &apos;바른한글&apos;로
+            이름을 변경하고 (주)나라인포테크에서 운영하고 있습니다.
+          </p>
           <p>이 검사기는 개인이나 학생만 무료로 사용할 수 있습니다.</p>
         </div>
 

--- a/src/pages/about/ui/about-page.tsx
+++ b/src/pages/about/ui/about-page.tsx
@@ -1,0 +1,86 @@
+import { CONTACT_INFO } from '@/shared/model/contact-info'
+import Image from 'next/image'
+import Link from 'next/link'
+
+export const AboutPage = () => {
+  return (
+    <div className='flex min-h-[calc(100vh-8rem)] w-full flex-col items-center px-4 py-10 pc:py-16'>
+      <div className='flex w-full max-w-[32rem] flex-col gap-8 pc:gap-10'>
+        {/* 상단: 기여자 안내 */}
+        <div className='flex flex-col items-center gap-2'>
+          <a
+            href='https://rogue-toothpaste-2b9.notion.site/1ee8bd6bfd808016995ff0b71b2cb358'
+            target='_blank'
+            rel='noopener noreferrer'
+            className='text-xs font-semibold text-primary hover:underline'
+          >
+            바른 한글 재단장에 기여하신 분들
+          </a>
+        </div>
+
+        {/* 고객센터 및 문의 */}
+        <div className='flex flex-col items-center gap-3 rounded-lg bg-slate-100 p-4 pc:flex-row pc:justify-center'>
+          <div className='flex flex-col items-center gap-1 pc:flex-row pc:justify-center'>
+            <span className='text-xs font-semibold tracking-[-0.015rem] pc:text-sm'>
+              <Link
+                href='/order'
+                className='hover:text-primary hover:underline'
+              >
+                구매문의
+              </Link>
+            </span>
+            <a
+              href={`tel:${CONTACT_INFO.tel.value}`}
+              className='text-slate-700 flex items-center gap-1 text-xs hover:text-primary'
+            >
+              <div className='relative size-4'>
+                <Image
+                  className='object-cover'
+                  src='/call.svg'
+                  alt='전화 아이콘'
+                  fill
+                />
+              </div>
+              <span>{CONTACT_INFO.tel.label}</span>
+            </a>
+            <a
+              href={`mailto:${CONTACT_INFO.email.value}`}
+              className='text-slate-700 flex items-center gap-1 text-xs hover:text-primary'
+            >
+              <div className='relative size-4'>
+                <Image
+                  className='object-cover'
+                  src='/email.svg'
+                  alt='이메일 아이콘'
+                  fill
+                />
+              </div>
+              <span>{CONTACT_INFO.email.label}</span>
+            </a>
+          </div>
+        </div>
+
+        {/* 저작권 및 소개 */}
+        <div className='flex flex-col gap-2 text-center text-xs text-slate-500 pc:text-sm'>
+          {/* PC/모바일 반응형 소개 */}
+          <div>
+            <p className='pc:hidden'>바른 한글은 부산대학교 인공지능연구실과</p>
+            <p className='pc:hidden'>
+              (주)나라인포테크가 함께 만들고 있습니다.
+            </p>
+            <p className='hidden pc:block'>
+              바른 한글은 부산대학교 인공지능연구실과 (주)나라인포테크가 함께
+              만들고 있습니다.
+            </p>
+          </div>
+          <p>이 검사기는 개인이나 학생만 무료로 사용할 수 있습니다.</p>
+        </div>
+
+        {/* 카피라이트 */}
+        <div className='border-t border-slate-200 pt-2 text-center text-[0.7rem] text-slate-400'>
+          Copyrightⓒ2001 AI Lab &amp; Narainfotech. All Rights Reserved
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/about/ui/about-page.tsx
+++ b/src/pages/about/ui/about-page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 
 export const AboutPage = () => {
   return (
-    <div className='flex min-h-[calc(100vh-8rem)] w-full flex-col items-center px-4 py-10 pc:py-16'>
+    <div className='flex w-full flex-col items-center px-4 py-10 pc:py-16'>
       <div className='flex w-full max-w-[32rem] flex-col gap-8 pc:gap-10'>
         {/* 상단: 기여자 안내 */}
         <div className='flex flex-col items-center gap-2'>

--- a/src/pages/feedback/ui/contact-info.tsx
+++ b/src/pages/feedback/ui/contact-info.tsx
@@ -1,0 +1,44 @@
+import { CONTACT_INFO } from '@/shared/model/contact-info'
+import Link from 'next/link'
+import React from 'react'
+import Image from 'next/image'
+
+export const ContactInfo = () => {
+  return (
+    <div className='flex gap-2 text-slate-600'>
+      <span className='text-xs font-semibold leading-[1.0425rem] tracking-[-0.015rem] tab:leading-[1.05rem] pc:text-[0.75rem] pc:leading-[1.035rem] pc:tracking-[-0.015rem]'>
+        <Link href='/order' className='hover:text-primary hover:underline'>
+          구매문의
+        </Link>
+      </span>
+      <a
+        href={`tel:${CONTACT_INFO.tel.value}`}
+        className='flex items-center gap-1 text-[0.6875rem] leading-[0.95563rem] tracking-[-0.01375rem] tab:leading-[0.9625rem] pc:text-[0.75rem] pc:leading-[1.035rem] pc:tracking-[-0.015rem]'
+      >
+        <div className='relative size-[0.83038rem]'>
+          <Image
+            className='object-cover'
+            src='/call.svg'
+            alt='call logo'
+            fill
+          />
+        </div>
+        <span>{CONTACT_INFO.tel.label}</span>
+      </a>
+      <a
+        href={`mailto:${CONTACT_INFO.email.value}`}
+        className='flex items-center gap-1 text-[0.6875rem] leading-[0.95563rem] tracking-[-0.01375rem] tab:leading-[0.9625rem]'
+      >
+        <div className='relative mb-[0.05rem] size-[0.83038rem]'>
+          <Image
+            className='object-cover'
+            src='/email.svg'
+            alt='email logo'
+            fill
+          />
+        </div>
+        <span>{CONTACT_INFO.email.label}</span>
+      </a>
+    </div>
+  )
+}

--- a/src/pages/feedback/ui/contact-info.tsx
+++ b/src/pages/feedback/ui/contact-info.tsx
@@ -5,15 +5,15 @@ import Image from 'next/image'
 
 export const ContactInfo = () => {
   return (
-    <div className='flex gap-2 text-slate-600'>
-      <span className='text-xs font-semibold leading-[1.0425rem] tracking-[-0.015rem] tab:leading-[1.05rem] pc:text-[0.75rem] pc:leading-[1.035rem] pc:tracking-[-0.015rem]'>
+    <div className='flex gap-2 text-xs text-slate-600 tab:text-base'>
+      <span className='font-semibold leading-[1.0425rem] tracking-[-0.015rem] tab:leading-[1.05rem] pc:leading-[1.035rem] pc:tracking-[-0.015rem]'>
         <Link href='/order' className='hover:text-primary hover:underline'>
           구매문의
         </Link>
       </span>
       <a
         href={`tel:${CONTACT_INFO.tel.value}`}
-        className='flex items-center gap-1 text-[0.6875rem] leading-[0.95563rem] tracking-[-0.01375rem] tab:leading-[0.9625rem] pc:text-[0.75rem] pc:leading-[1.035rem] pc:tracking-[-0.015rem]'
+        className='flex items-center gap-1 leading-[0.95563rem] tracking-[-0.01375rem] tab:leading-[0.9625rem] pc:leading-[1.035rem] pc:tracking-[-0.015rem]'
       >
         <div className='relative size-[0.83038rem]'>
           <Image
@@ -27,7 +27,7 @@ export const ContactInfo = () => {
       </a>
       <a
         href={`mailto:${CONTACT_INFO.email.value}`}
-        className='flex items-center gap-1 text-[0.6875rem] leading-[0.95563rem] tracking-[-0.01375rem] tab:leading-[0.9625rem]'
+        className='flex items-center gap-1 leading-[0.95563rem] tracking-[-0.01375rem] tab:leading-[0.9625rem]'
       >
         <div className='relative mb-[0.05rem] size-[0.83038rem]'>
           <Image

--- a/src/pages/feedback/ui/feedback-form.tsx
+++ b/src/pages/feedback/ui/feedback-form.tsx
@@ -8,6 +8,7 @@ import { Label } from '@/shared/ui/label'
 import { TextCounter } from '@/shared/ui/text-counter'
 import { Textarea } from '@/shared/ui/textarea'
 import { feedbackReportAction } from '../api/feedback-report-action'
+import { ContactInfo } from './contact-info'
 
 const FeedbackForm = () => {
   const router = useRouter()
@@ -50,7 +51,8 @@ const FeedbackForm = () => {
         </div>
       </div>
       {/* 폼 전송 버튼 */}
-      <div className='mt-3 pb-[5.4375rem] text-end tab:mt-4'>
+      <div className='mt-3 flex items-center justify-between pb-[5.4375rem] text-end tab:mt-4'>
+        <ContactInfo />
         <Button
           className='h-[3.375rem] w-full text-lg tab:w-32 pc:h-16 pc:w-[9.625rem] pc:text-[1.375rem]'
           type='submit'

--- a/src/pages/feedback/ui/feedback-form.tsx
+++ b/src/pages/feedback/ui/feedback-form.tsx
@@ -51,7 +51,7 @@ const FeedbackForm = () => {
         </div>
       </div>
       {/* 폼 전송 버튼 */}
-      <div className='mt-3 flex items-center justify-between pb-[5.4375rem] text-end tab:mt-4'>
+      <div className='mt-3 flex flex-col-reverse items-center justify-between gap-2 pb-[5.4375rem] text-end tab:mt-4 pc:flex-row'>
         <ContactInfo />
         <Button
           className='h-[3.375rem] w-full text-lg tab:w-32 pc:h-16 pc:w-[9.625rem] pc:text-[1.375rem]'

--- a/src/shared/ui/footer.tsx
+++ b/src/shared/ui/footer.tsx
@@ -1,13 +1,9 @@
 'use client'
 
-import { usePathname } from 'next/navigation'
 import { cn } from '../lib/tailwind-merge'
 import { FooterAdSense } from './footer-ad-sense'
-import { FooterInfoSection } from './footer-info-section'
 
 const Footer = () => {
-  const pathname = usePathname()
-  const isInfoHidden = pathname === '/results'
   return (
     <>
       <FooterAdSense includeDevice={['mobile', 'tablet']} />
@@ -18,11 +14,9 @@ const Footer = () => {
       >
         <div
           className={cn(
-            'flex h-full flex-col items-center pc-lg:container pc:mx-auto pc:w-full pc:flex-row pc:justify-between pc:space-x-7 pc:px-[2.25rem] pc:py-2 pc-lg:space-x-0 pc-lg:px-[4.5rem]',
-            isInfoHidden && 'pc:justify-center pc:space-x-0',
+            'flex h-full flex-col items-center pc-lg:container pc:mx-auto pc:w-full pc:flex-row pc:justify-center pc:space-x-0 pc:px-[2.25rem] pc:py-2 pc-lg:space-x-0 pc-lg:px-[4.5rem]',
           )}
         >
-          {!isInfoHidden && <FooterInfoSection />}
           <FooterAdSense includeDevice={['desktop', 'desktop-large']} />
         </div>
       </footer>

--- a/src/shared/ui/header.tsx
+++ b/src/shared/ui/header.tsx
@@ -28,6 +28,9 @@ const Header = () => {
           <Link href='/feedback' className={classes.linkButton}>
             문의하기
           </Link>
+          <Link href='/about' className={classes.linkButton}>
+            소개
+          </Link>
           <Link
             href='https://nara-speller.co.kr/old_speller/'
             className='hidden rounded-lg border border-[#B8B8BE] p-3 font-semibold !leading-none text-slate-500 hover:bg-accent tab:inline-flex tab:text-xl pc:text-base'
@@ -63,6 +66,14 @@ const Header = () => {
                     className={`${classes.popoverIcon} bg-icon-question group-hover:bg-icon-question-white`}
                   />
                   문의하기
+                </Link>
+              </li>
+              <li className='group'>
+                <Link href='/about' className={classes.popoverButton}>
+                  <i
+                    className={`${classes.popoverIcon} bg-icon-question group-hover:bg-icon-question-white`}
+                  />
+                  소개
                 </Link>
               </li>
               <li className='group'>


### PR DESCRIPTION
## pc

<img width="700"  alt="image" src="https://github.com/user-attachments/assets/8d517c98-ee26-4ccc-9839-8088373ad6c7" />


## mo
<img width="401" height="485" alt="image" src="https://github.com/user-attachments/assets/12f53db3-e832-473a-a683-1ba98571ec0e" />

## 기타
<img width="700" height="1093" alt="image" src="https://github.com/user-attachments/assets/55b275f4-4747-44a2-b08c-b78870bab2fa" />

기존 푸터에 있던 `{!isInfoHidden && <FooterInfoSection />}` 처리를 제거하고 모든 화면 공통으로 광고만 나오도록 조정했습니다. (푸터에 표시되던 서비스 정보 모두 제거)
