### PR TITLE
feat: 버전 정보 표시 (#254)

### DIFF
--- a/src/entities/speller/api/speller-service.ts
+++ b/src/entities/speller/api/speller-service.ts
@@ -6,6 +6,7 @@ import {
   NotChangePayload,
   SpellerService,
   UserReplacePayload,
+  VersionResponse,
 } from '../model/speller-interface'
 import {
   CheckPayload,
@@ -34,6 +35,10 @@ class SpellerApiService implements SpellerService {
 
   async notChange(payload: NotChangePayload) {
     return this.#client.post(ENDPOINT.NOT_CHANGE, payload)
+  }
+
+  async version(): Promise<AxiosResponse<VersionResponse>> {
+    return this.#client.post(ENDPOINT.VERSION)
   }
 }
 

--- a/src/entities/speller/model/speller-interface.ts
+++ b/src/entities/speller/model/speller-interface.ts
@@ -17,9 +17,14 @@ export type NotChangePayload = {
   sentence: string // 오류 문자열을 포함한 주변 문맥 문자열 (오류 문자열 좌/우)
 }[]
 
+export interface VersionResponse {
+  curVersion: string
+}
+
 export interface SpellerService {
   check: (payload: CheckPayload) => Promise<AxiosResponse<CheckResponse>>
   logUserReplace: (payload: UserReplacePayload) => void
   logClickReplace: (payload: ClickReplacePayload) => void
   notChange: (payload: NotChangePayload) => void
+  version: () => void
 }

--- a/src/pages/speller/api/version-action.ts
+++ b/src/pages/speller/api/version-action.ts
@@ -1,0 +1,16 @@
+'use server'
+
+import { SpellerApi } from '@/entities/speller'
+import { VersionResponse } from '@/entities/speller/model/speller-interface'
+
+const spellCheckVersionAction = async (): Promise<VersionResponse> => {
+  try {
+    const { data } = await SpellerApi.version()
+    return data
+  } catch (error) {
+    console.error('Error fetching version:', error)
+    return { curVersion: '' }
+  }
+}
+
+export { spellCheckVersionAction }

--- a/src/pages/speller/ui/speller-page.tsx
+++ b/src/pages/speller/ui/speller-page.tsx
@@ -17,6 +17,7 @@ import {
   sendCheckResultResponseErrorEvent,
   sendCheckResultResponseUnknownEvent,
 } from '@/shared/lib/send-ga-event'
+import { VersionInfo } from './version-info'
 
 const SpellerPage = () => {
   const router = useRouter()
@@ -105,8 +106,9 @@ const SpellerPage = () => {
     <>
       <form action={formAction} className='flex-1'>
         <ContentLayout className='min-h-[35.75rem] pb-4 pc:pb-5'>
-          {/* 강한 검사 */}
-          <div className='mb-2 mt-[0.94rem] min-h-[1.625rem] tab:mt-[1.75rem] pc:mb-[0.78rem] pc:mt-[1.97rem] pc:min-h-8'>
+          {/* 강한 검사 및 버전*/}
+          <div className='mb-2 mt-[0.94rem] flex min-h-[1.625rem] items-center justify-between tab:mt-[1.75rem] pc:mb-[0.78rem] pc:mt-[1.97rem] pc:min-h-8'>
+            <VersionInfo />
             <SpellerSetting />
           </div>
           <div className='flex h-full w-full flex-col rounded-lg bg-white p-4 tab:rounded-[1rem] tab:p-5 pc:p-6'>

--- a/src/pages/speller/ui/version-info.tsx
+++ b/src/pages/speller/ui/version-info.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { spellCheckVersionAction } from '../api/version-action'
+
+export const VersionInfo = () => {
+  const [version, setVersion] = useState('')
+
+  useEffect(() => {
+    const fetchVersion = async () => {
+      const { curVersion } = await spellCheckVersionAction()
+      setVersion(curVersion)
+    }
+
+    fetchVersion()
+  }, [])
+
+  return <div>{version}</div>
+}

--- a/src/shared/config/api.ts
+++ b/src/shared/config/api.ts
@@ -7,4 +7,5 @@ export const ENDPOINT = {
   SEND_REPORT_MAIL: '/sendReportMail',
   FILTER_IP: '/filterIP',
   CHECK_IP: '/client-api/check-ip', // API Route
+  VERSION: '/version',
 }


### PR DESCRIPTION
## 작업 내역
- 메인 페이지에 /version API를 이용해 최종 업데이트 날짜를 표시하는 컴포넌트 추가

### PC
<img width="700" height="851" alt="image" src="https://github.com/user-attachments/assets/dde5fc5e-234d-4c34-94f2-d22d02b653c9" />

### MO
<img width="385" height="513" alt="image" src="https://github.com/user-attachments/assets/d3a3552f-030b-452f-b246-3d2e591f954f" />

### 참고 사항
검사 결과 화면에는 버전이 표시되지 않습니다.
<img width="700" height="848" alt="image" src="https://github.com/user-attachments/assets/115b9bfc-822d-499c-aa27-cd1f101a464a" />

close #254 
