### PR TITLE
fix: 사이트 메타데이터 title 수정 (#259)

### DIFF
--- a/app/(base-layout)/speller/page.tsx
+++ b/app/(base-layout)/speller/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next'
 
 // 이 페이지의 Metadata 객체
 export const metadata: Metadata = {
-  title: '바른한글',
+  title: '바른한글(구 한국어 맞춤법/문법 검사기)',
   description:
     '한국어 맞춤법과 문법을 자동으로 검사하고 교정해주는 무료 온라인 도구입니다. 띄어쓰기, 맞춤법, 문장 구조를 분석하여 정확하고 자연스러운 한국어 작성을 도와드립니다.',
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import { App } from '@/app'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: '바른 한글',
+  title: '바른한글(구 한국어 맞춤법/문법 검사기)',
   description:
     '한국어 맞춤법과 문법을 자동으로 검사하고 교정해주는 무료 온라인 도구입니다. 띄어쓰기, 맞춤법, 문장 구조를 분석하여 정확하고 자연스러운 한국어 작성을 도와드립니다.',
 }


### PR DESCRIPTION
- 현재 사이트의 메타데이터에서 title 태그를 아래와 같이 수정
  - 현재 title: 바른한글
  - 변경할 title: 바른한글(구 한국어 맞춤법/문법 검사기)