### PR TITLE
소개 및 문의하기 페이지 폰트 크기 조정 (#261)

### DIFF
--- a/src/pages/about/ui/about-page.tsx
+++ b/src/pages/about/ui/about-page.tsx
@@ -1,21 +1,21 @@
 export const AboutPage = () => {
   return (
-    <div className='flex w-full flex-col items-center px-4 py-10 pc:py-16'>
-      <div className='flex w-full max-w-[32rem] flex-col gap-8 pc:gap-10'>
+    <div className='flex w-full flex-col items-center px-4 py-10 text-base leading-[140%] tracking-[-0.02rem] tab:text-lg tab:tracking-[-0.0225rem] pc:py-16 pc:text-[1.375rem] pc:leading-[170%] pc:tracking-[-0.0275rem]'>
+      <div className='flex w-full flex-col gap-8 pc:gap-10'>
         {/* 상단: 기여자 안내 */}
         <div className='flex flex-col items-center gap-2'>
           <a
             href='https://rogue-toothpaste-2b9.notion.site/1ee8bd6bfd808016995ff0b71b2cb358'
             target='_blank'
             rel='noopener noreferrer'
-            className='text-xs font-semibold text-primary hover:underline'
+            className='font-semibold text-primary hover:underline'
           >
             바른 한글 재단장에 기여하신 분들
           </a>
         </div>
 
         {/* 저작권 및 소개 */}
-        <div className='flex flex-col gap-2 text-center text-xs text-slate-500 pc:text-sm'>
+        <div className='flex flex-col gap-2 text-center text-slate-500'>
           {/* PC/모바일 반응형 소개 */}
           <p>
             &apos;바른한글&apos;은 &apos;한국어 맞춤법/문법 검사기&apos;의 새
@@ -23,14 +23,15 @@ export const AboutPage = () => {
           </p>
           <p>
             &apos;한국어 맞춤법/문법 검사기&apos;는 인공지능연구실과
-            (주)나라인포테크가 함께 만들었으며, 현재는 &apos;바른한글&apos;로
-            이름을 변경하고 (주)나라인포테크에서 운영하고 있습니다.
+            (주)나라인포테크가 함께 만들었으며, <br />
+            현재는 &apos;바른한글&apos;로 이름을 변경하고 (주)나라인포테크에서
+            운영하고 있습니다.
           </p>
           <p>이 검사기는 개인이나 학생만 무료로 사용할 수 있습니다.</p>
         </div>
 
         {/* 카피라이트 */}
-        <div className='border-t border-slate-200 pt-2 text-center text-[0.7rem] text-slate-400'>
+        <div className='border-t border-slate-200 pt-2 text-center text-slate-400'>
           Copyrightⓒ2001 AI Lab &amp; Narainfotech. All Rights Reserved
         </div>
       </div>

--- a/src/pages/order/ui/order-page.tsx
+++ b/src/pages/order/ui/order-page.tsx
@@ -107,7 +107,7 @@ export const OrderPage = () => {
           <h3 className='text-xl font-semibold leading-[2.4rem] pc:text-2xl'>
             구매 문의
           </h3>
-          <p className='text-sm text-slate-300'>
+          <p className='text-slate-300'>
             {CONTACT_INFO.email.label}({CONTACT_INFO.email.value})
             <br />
             {CONTACT_INFO.tel.label}({CONTACT_INFO.tel.value})


### PR DESCRIPTION
## 소개하기
- 문의하기 페이지와 동일하게 pc는 19.26px, mo는 14px로 폰트 크기 수정

<img width="700" height="744" alt="image" src="https://github.com/user-attachments/assets/ef512d0a-d946-4255-b27f-28701ad7d927" />
<img width="353" height="315" alt="image" src="https://github.com/user-attachments/assets/2d47f8e6-925c-48ad-b48a-988a6b1cabe8" />

## 구매문의
- 구매 문의 부분의 텍스트를 12.25px 에서 14px로 수정
<img width="700" height="735" alt="image" src="https://github.com/user-attachments/assets/87381f01-8f6d-4812-a8d1-4d68ca4ad44e" />
<img width="353" height="366" alt="image" src="https://github.com/user-attachments/assets/427b6784-affe-40b7-80ab-3e815bfe3d57" />
