### PR TITLE
design: 페이지네이션 상시 고정되도록 스타일 수정 (#263)

### DIFF
--- a/src/pages/results/ui/results-page.tsx
+++ b/src/pages/results/ui/results-page.tsx
@@ -51,7 +51,7 @@ const ResultsPage = ({ pageParam = '1' }: ResultsPageProps) => {
   return (
     <SpellerRefsProvider>
       <ContentLayout className='pb-4 tab:pb-10 pc:pb-5'>
-        <div className='sticky -top-2 z-10 flex min-h-[1.625rem] items-center justify-between bg-background pb-2 pt-4 tab:-top-3 tab:justify-center tab:pt-[1.25rem] pc:relative pc:top-0 pc:min-h-8 pc:pb-3 pc:pt-6'>
+        <div className='sticky -top-2 z-10 flex min-h-[1.625rem] items-center justify-between bg-background pb-2 pt-4 tab:-top-3 tab:justify-center tab:pt-[1.25rem] pc:min-h-8 pc:pb-3 pc:pt-6'>
           <Navigator currentPage={Number(pageParam)} />
           <StrongCheckMessage />
         </div>

--- a/src/pages/speller/ui/speller-control.tsx
+++ b/src/pages/speller/ui/speller-control.tsx
@@ -9,7 +9,7 @@ import { sendCheckTriggeredEvent } from '@/shared/lib/send-ga-event'
 
 const SpellerControl = () => {
   const { text, isStrictCheck } = useSpeller()
-  const textLength = text.length
+  const textLength = text?.length
   const isButtonDisabled = textLength <= 0
 
   return (


### PR DESCRIPTION
## 작업 내역
- 페이지네이션이 모든 디바이스에서 상시 상단 고정되도록 css를 수정했습니다.

## 스크린샷

### mo
<img width="422" height="832" alt="스크린샷 2025-08-04 오후 8 33 20" src="https://github.com/user-attachments/assets/10c67489-562a-477c-802f-9f6166d452ed" />

### tab
<img width="764" height="792" alt="스크린샷 2025-08-04 오후 8 33 10" src="https://github.com/user-attachments/assets/be6976aa-7556-4434-bb24-cf7debde6098" />

### pc
<img width="1799" height="906" alt="스크린샷 2025-08-04 오후 8 29 25" src="https://github.com/user-attachments/assets/e54882e1-eb4a-4747-a89d-ef0cd6865ff1" />

close #263 