### PR TITLE
페이지 안내/복사 완료 Toast 동작 오류 및 위치 개선

### DIFF
--- a/src/pages/results/ui/navigator.tsx
+++ b/src/pages/results/ui/navigator.tsx
@@ -129,6 +129,8 @@ const Navigator = ({ currentPage: propCurrentPage }: NavigatorProps) => {
 
   useEffect(() => {
     if (response.totalPageCnt <= 1) return
+    if (currentPage > 1) return // 1 페이지에서만 토스트 표시
+
     toast({
       variant: 'noIcon',
       description: `총 ${response.totalPageCnt} 페이지입니다.\n화살표를 눌러 페이지를 이동해 주세요.`,

--- a/src/shared/lib/use-toast.ts
+++ b/src/shared/lib/use-toast.ts
@@ -6,8 +6,7 @@ import * as React from 'react'
 import type { ToastActionElement, ToastProps } from '@/shared/ui/toast'
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
-
+const TOAST_REMOVE_DELAY = 2000
 type ToasterToast = ToastProps & {
   id: string
   title?: React.ReactNode

--- a/src/shared/ui/toast.tsx
+++ b/src/shared/ui/toast.tsx
@@ -16,7 +16,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      'sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px] fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse items-center p-4',
+      'fixed left-1/2 top-24 z-[100] flex w-full -translate-x-1/2 transform justify-center p-4 tab:block tab:w-auto',
       className,
     )}
     {...props}
@@ -77,7 +77,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      'group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600 absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100',
+      'group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600 absolute right-2 top-2 rounded-md p-1 text-foreground/50 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2',
       className,
     )}
     toast-close=''

--- a/src/shared/ui/toaster.tsx
+++ b/src/shared/ui/toaster.tsx
@@ -17,7 +17,7 @@ export function Toaster() {
   const { toasts } = useToast()
 
   return (
-    <ToastProvider swipeDirection='up' duration={3000}>
+    <ToastProvider swipeDirection='up' duration={2000}>
       {toasts.map(function ({ id, title, description, action, ...props }) {
         return (
           <Toast key={id} {...props}>

--- a/src/shared/ui/toaster.tsx
+++ b/src/shared/ui/toaster.tsx
@@ -11,10 +11,24 @@ import {
 } from '@/shared/ui/toast'
 import WarningIcon from '@/shared/ui/icon/toast-warning.svg'
 import CheckIcon from '@/shared/ui/icon/toast-check.svg'
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 
 export function Toaster() {
-  const { toasts } = useToast()
+  const { toasts, dismiss } = useToast()
+  const viewportRef = useRef<HTMLOListElement>(null)
+
+  useEffect(() => {
+    if (toasts.length === 0) return
+
+    function handleClickOutside() {
+      if (!viewportRef.current) return
+      // 외부 클릭 시 모든 토스트 닫기
+      toasts.forEach(t => dismiss(t.id))
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [toasts, dismiss])
 
   return (
     <ToastProvider swipeDirection='up' duration={2000}>
@@ -45,7 +59,7 @@ export function Toaster() {
           </Toast>
         )
       })}
-      <ToastViewport />
+      <ToastViewport ref={viewportRef} />
     </ToastProvider>
   )
 }


### PR DESCRIPTION
## 작업 내역
- 페이지네이션 버튼 하위로 토스트 위치 조정
- 외부 클릭 시 토스트 닫히도록 개선
- 1페이지에서만 페이지 안내 토스트 표시하도록 수정

## 특이 사항
윈도우 포커스를 잃었을 때 토스트가 사라지지 않던 문제는 타이머 시간이 잘못 설정된 것이 원인이었으며, 해당 부분을 수정하였습니다.
다만, 토스트에 마우스를 올려두면 타이머가 동작하지 않는데 이는 해당 토스트 라이브러리의 기본 동작입니다.
현재는 클릭 이벤트 발생 시 즉시 사라지기 때문에 큰 불편은 없을 것으로 보이나, 마우스 오버 상태에서도 타이머가 동작하도록 개선이 필요하시다면 말씀 부탁드립니다.

## 스크린샷
토스트 위치는 현재 확인 요청드린 상태이며, 아직 확정되지 않았습니다.

<img width="700" height="1448" alt="image" src="https://github.com/user-attachments/assets/5f5f4018-fc80-4ec9-ada4-38f8afb8b404" />
<img width="422" height="1008" alt="image" src="https://github.com/user-attachments/assets/3621e359-d5e0-4890-b686-882ca43b0478" />


Closes #258 