### PR TITLE
feat: ga4 이전 버전 사용하기 및 버튼 클릭 이벤트 추가 (#281)

### DIFF
--- a/src/pages/results/ui/results-control.tsx
+++ b/src/pages/results/ui/results-control.tsx
@@ -10,6 +10,7 @@ import { TextCounter } from '@/shared/ui/text-counter'
 import { toast } from '@/shared/lib/use-toast'
 import { getWordsAroundIndex } from '@/shared/lib/util'
 import { logCopyAction } from '../api/log-copy-action'
+import { sendButtonClickedEvent } from '@/shared/lib/send-ga-event'
 
 const ResultsControl = () => {
   const {
@@ -68,6 +69,9 @@ const ResultsControl = () => {
           ariaLabel='새글쓰기'
           onClick={() => {
             handleOriginalTextChange('')
+            sendButtonClickedEvent({
+              buttonType: 'write',
+            })
             router.push('/speller')
           }}
         />
@@ -75,19 +79,34 @@ const ResultsControl = () => {
           icon='/arrow-return-left.svg'
           label='돌아가기'
           ariaLabel='이전 페이지로 돌아가기'
-          onClick={() => router.push('/speller')}
+          onClick={() => {
+            sendButtonClickedEvent({
+              buttonType: 'back',
+            })
+            router.push('/speller')
+          }}
         />
         <ActionButton
           icon='/copy.svg'
           label='복사하기'
           ariaLabel='텍스트 복사하기'
-          onClick={() => handleCopy(displayText)}
+          onClick={() => {
+            handleCopy(displayText)
+            sendButtonClickedEvent({
+              buttonType: 'partial_copy',
+            })
+          }}
         />
         <ActionButton
           icon='/copy.svg'
           label='전체복사'
           ariaLabel='전체 텍스트 복사하기'
-          onClick={() => handleCopy(correctedText)}
+          onClick={() => {
+            handleCopy(correctedText)
+            sendButtonClickedEvent({
+              buttonType: 'all_copy',
+            })
+          }}
         />
       </div>
     </div>

--- a/src/pages/speller/ui/speller-text-input.tsx
+++ b/src/pages/speller/ui/speller-text-input.tsx
@@ -6,6 +6,7 @@ import { useSpeller } from '@/entities/speller'
 import { ScrollGradientFade } from '@/shared/ui/scroll-gradient-fade'
 import { Textarea, TextareaHandle } from '@/shared/ui/textarea'
 import { Button } from '@/shared/ui/button'
+import { sendButtonClickedEvent } from '@/shared/lib/send-ga-event'
 
 const SpellerTextInput = () => {
   const textareaRef = useRef<TextareaHandle>(null)
@@ -16,6 +17,10 @@ const SpellerTextInput = () => {
     if (!textareaRef.current) return
 
     textareaRef.current.textClear()
+
+    sendButtonClickedEvent({
+      buttonType: 'remove',
+    })
   }, [])
 
   const handleScroll = useCallback(

--- a/src/shared/lib/analytics-event-types.ts
+++ b/src/shared/lib/analytics-event-types.ts
@@ -12,6 +12,8 @@ export const GA_ACTIONS = {
   MANUAL_CORRECTION_SUBMITTED: 'manual_correction_submitted',
   CORRECTION_FEEDBACK_OPENED: 'correction_feedback_opened',
   CORRECTION_FEEDBACK_SUBMITTED: 'correction_feedback_submitted',
+  PREVIOUS_VERSION_CLICKED: 'previous_version_clicked',
+  BUTTON_CLICKED: 'button_clicked',
 } as const
 
 export const GA_EVENT_TYPE = {
@@ -42,6 +44,15 @@ export const SECTION = [
 export type SectionType = (typeof SECTION)[number]
 
 export const ERROR_STAGE = ['unknown', 'timeout', 'request'] as const
+
+export const BUTTON_TYPE = [
+  'write',
+  'remove',
+  'back',
+  'partial_copy',
+  'all_copy',
+] as const
+export type ButtonType = (typeof BUTTON_TYPE)[number]
 
 export const CheckTriggeredSchema = z.object({
   original_text_length: z.number(),
@@ -121,6 +132,15 @@ export const CorrectionFeedbackSubmittedSchema = z.object({
   corrected_error_type: z.enum(CORRECTED_ERROR_TYPE),
 })
 
+export const PreviousVersionClickedSchema = z.object({
+  method: z.enum(METHOD),
+})
+
+export const ButtonClickedSchema = z.object({
+  method: z.enum(METHOD),
+  button_type: z.enum(BUTTON_TYPE),
+})
+
 export type CheckTriggeredParams = z.infer<typeof CheckTriggeredSchema>
 export type CheckCompletedParams = z.infer<typeof CheckCompletedSchema>
 export type CheckResultNoErrorParams = z.infer<typeof CheckResultNoErrorSchema>
@@ -144,6 +164,10 @@ export type CorrectionFeedbackOpenedParams = z.infer<
 export type CorrectionFeedbackSubmittedParams = z.infer<
   typeof CorrectionFeedbackSubmittedSchema
 >
+export type PreviousVersionClickedParams = z.infer<
+  typeof PreviousVersionClickedSchema
+>
+export type ButtonClickedParams = z.infer<typeof ButtonClickedSchema>
 
 type GAEventMap = {
   checkTriggered: z.infer<typeof CheckTriggeredSchema>
@@ -157,6 +181,8 @@ type GAEventMap = {
   manualCorrectionSubmitted: z.infer<typeof ManualCorrectionSubmittedSchema>
   correctionFeedbackOpened: z.infer<typeof CorrectionFeedbackOpenedSchema>
   correctionFeedbackSubmitted: z.infer<typeof CorrectionFeedbackSubmittedSchema>
+  previousVersionClicked: z.infer<typeof PreviousVersionClickedSchema>
+  buttonClicked: z.infer<typeof ButtonClickedSchema>
 }
 
 export type GAEventTrackerMap = {

--- a/src/shared/lib/send-ga-event.ts
+++ b/src/shared/lib/send-ga-event.ts
@@ -18,6 +18,9 @@ import {
   ManualCorrectionSubmittedParams,
   CorrectionFeedbackOpenedParams,
   CorrectionFeedbackSubmittedParams,
+  PreviousVersionClickedParams,
+  ButtonClickedParams,
+  ButtonType,
 } from './analytics-event-types'
 
 type Event = (typeof GA_EVENT_TYPE)[keyof typeof GA_EVENT_TYPE]
@@ -88,6 +91,14 @@ const GAEvents: GAEventTrackerMap = {
   correctionFeedbackSubmitted: createTracker<CorrectionFeedbackSubmittedParams>(
     GA_EVENT_TYPE.EVENT,
     GA_ACTIONS.CORRECTION_FEEDBACK_SUBMITTED,
+  ),
+  previousVersionClicked: createTracker<PreviousVersionClickedParams>(
+    GA_EVENT_TYPE.EVENT,
+    GA_ACTIONS.PREVIOUS_VERSION_CLICKED,
+  ),
+  buttonClicked: createTracker<ButtonClickedParams>(
+    GA_EVENT_TYPE.EVENT,
+    GA_ACTIONS.BUTTON_CLICKED,
   ),
 }
 
@@ -378,5 +389,29 @@ export const sendCorrectionFeedbackSubmittedEvent = ({
     corrected_error_type: correctedErrorType,
     section: sectionType,
     method: 'button',
+  })
+}
+
+/**
+ * 이전 버전 사용하기 버튼 클릭 시 GA 이벤트를 전송합니다.
+ */
+export const sendPreviousVersionClickedEvent = () => {
+  GAEvents.previousVersionClicked({
+    method: 'button',
+  })
+}
+
+/**
+ * 교정 문서 버튼 클릭 시 GA 이벤트를 전송합니다.
+ * @param buttonType 클릭된 버튼 유형
+ */
+export const sendButtonClickedEvent = ({
+  buttonType,
+}: {
+  buttonType: ButtonType
+}) => {
+  GAEvents.buttonClicked({
+    method: 'button',
+    button_type: buttonType,
   })
 }

--- a/src/shared/ui/header.tsx
+++ b/src/shared/ui/header.tsx
@@ -1,9 +1,23 @@
+'use client'
+
 import Image from 'next/image'
 import Link from 'next/link'
 import { Button } from './button'
 import { Popover, PopoverContent, PopoverTrigger } from './popover'
+import { sendPreviousVersionClickedEvent } from '../lib/send-ga-event'
 
 const Header = () => {
+  const handlePreviousVersionClick = (
+    e: React.MouseEvent<HTMLAnchorElement>,
+  ) => {
+    e.preventDefault()
+    sendPreviousVersionClickedEvent()
+    // GA 이벤트 전송을 잠깐 기다린 후 이동
+    setTimeout(() => {
+      window.location.href = 'https://nara-speller.co.kr/old_speller/'
+    }, 200)
+  }
+
   return (
     <div className='flex items-center justify-center bg-white'>
       <header className='flex flex-1 items-center justify-between p-[1rem_1.5rem] pc-lg:container tab:p-[1.25rem_3.75rem] pc:w-full pc:p-[1rem_1.875rem] pc-lg:p-[1.25rem_2rem]'>
@@ -31,12 +45,13 @@ const Header = () => {
           <Link href='/feedback' className={classes.linkButton}>
             문의하기
           </Link>
-          <Link
-            href='https://nara-speller.co.kr/old_speller/'
+          <a
+            href='#'
             className='hidden rounded-lg border border-[#B8B8BE] p-3 font-semibold !leading-none text-slate-500 hover:bg-accent tab:inline-flex tab:text-xl pc:text-base'
+            onClick={handlePreviousVersionClick}
           >
             이전 버전 사용하기
-          </Link>
+          </a>
         </div>
         <Popover>
           <PopoverTrigger asChild>
@@ -77,15 +92,16 @@ const Header = () => {
                 </Link>
               </li>
               <li className='group'>
-                <Link
-                  href='https://nara-speller.co.kr/old_speller/'
+                <a
+                  href='#'
                   className={`${classes.popoverButton} border-none`}
+                  onClick={handlePreviousVersionClick}
                 >
                   <i
                     className={`${classes.popoverIcon} bg-icon-history-back group-hover:bg-icon-history-back-white`}
                   />
                   이전 버전 사용하기
-                </Link>
+                </a>
               </li>
             </ul>
           </PopoverContent>


### PR DESCRIPTION
디자인팀 요청사항 중 아래 두 가지 항목 수집을 위해 이벤트 추가하였습니다.
1. 네 가지 버튼(새글쓰기 아이콘, X 아이콘, 돌아가기, 복사하기) 클릭률
 → 특히 'X 아이콘'이 기존 '다시 쓰기' 버튼을 대체한 뒤 클릭률 변화 확인 목적
    - 버튼 구분: 새글쓰기(write), 돌아가기(back), 부분 복사(partial_copy), 전체 복사(all_copy), x 아이콘(remove)
    - 이벤트명: button_clicked

2. 이전 버전 사용하기 클릭률
    - 이벤트명: previous_version_clicked


close #281 