### PR TITLE
fix: 현재 pageIdx를 가져오는 방식 수정 (#289)

### DIFF
--- a/src/entities/speller/model/use-speller.ts
+++ b/src/entities/speller/model/use-speller.ts
@@ -2,7 +2,6 @@
 
 import { useCallback } from 'react'
 import { shallowEqual } from 'react-redux'
-import { usePathname } from 'next/navigation'
 import { useAppDispatch, useAppSelector } from '@/shared/lib/use-redux'
 import {
   setOriginalText,
@@ -21,12 +20,6 @@ import { CorrectInfo } from './speller-schema'
 const useSpeller = () => {
   const dispatch = useAppDispatch()
   const state = useAppSelector(state => state.speller, shallowEqual)
-  const pathname = usePathname()
-
-  const getCurrentPage = () => {
-    const match = pathname?.match(/\/results\/(\d+)$/)
-    return match ? Number(match[1]) : 1
-  }
 
   const handleOriginalTextChange = useCallback(
     (value: string) => {
@@ -51,10 +44,14 @@ const useSpeller = () => {
 
   const updateCorrectInfo = useCallback(
     (payload: CorrectInfo) => {
-      const pageIdx = getCurrentPage()
+      let pageIdx = 1
+      if (typeof window !== 'undefined') {
+        const urlParams = new URLSearchParams(window.location.search)
+        pageIdx = Number(urlParams.get('page')) || 1
+      }
       dispatch(setCorrectInfo({ ...payload, pageIdx }))
     },
-    [dispatch, getCurrentPage],
+    [dispatch],
   )
 
   const updateErrInfoIndex = useCallback(


### PR DESCRIPTION
- getCurrentPage 함수가 페이지네이션 방식을 수정하기 전 상태에 맞게 구현되어 있었음
- 현재 페이지네이션 방식에 맞추어 pageIdx를 가져오는 방식을 바꿈 
- useSearchParams를 사용할 경우 페이지 이동 후 첫 호출 시에 바뀐 페이지 값으로 업데이트 되지 않는 문제가 발생
- window.location.search를 직접적으로 참조하여 가져오도록 함